### PR TITLE
Bootloader and upstream updates

### DIFF
--- a/.github/workflows/.dev.workflow.yml
+++ b/.github/workflows/.dev.workflow.yml
@@ -1,0 +1,36 @@
+name: Dev Workflow
+
+on:
+  push:
+    branches-ignore:
+      - xlink_upstream
+
+jobs:
+
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    
+    - name: Install dependencies
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install libusb
+
+    - name: Install dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install libusb-1.0-0-dev
+        sudo apt-get install libusb-1.0-0
+
+    - name: configure
+      run: cmake . -Bbuild
+
+    - name: build
+      run: cmake --build build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required(VERSION 3.2)
 set(TARGET_NAME "XLink")
-project(${TARGET_NAME} LANGUAGES C)
+project(${TARGET_NAME} LANGUAGES C CXX)
 
 include(XLink.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ target_compile_definitions(${TARGET_NAME}
         HAVE_STRUCT_TIMESPEC
         _CRT_SECURE_NO_WARNINGS
         USE_USB_VSC
-        XLINK_USE_BUS
     )
 
 if (ENABLE_MYRIAD_NO_BOOT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ target_compile_definitions(${TARGET_NAME}
         HAVE_STRUCT_TIMESPEC
         _CRT_SECURE_NO_WARNINGS
         USE_USB_VSC
+        XLINK_USE_BUS
     )
 
 if (ENABLE_MYRIAD_NO_BOOT)

--- a/pc/PlatformData.c
+++ b/pc/PlatformData.c
@@ -347,7 +347,7 @@ int usb_read(libusb_device_handle *f, void *data, size_t size)
     const int chunk_size = DEFAULT_CHUNKSZ;
     while(size > 0)
     {
-        int bt, ss = size;
+        int bt, ss = (int)size;
         if(ss > chunk_size)
             ss = chunk_size;
 #if (defined(_WIN32) || defined(_WIN64))
@@ -368,7 +368,7 @@ int usb_write(libusb_device_handle *f, const void *data, size_t size)
     const int chunk_size = DEFAULT_CHUNKSZ;
     while(size > 0)
     {
-        int bt, ss = size;
+        int bt, ss = (int)size;
         if(ss > chunk_size)
             ss = chunk_size;
 #if (defined(_WIN32) || defined(_WIN64) )

--- a/pc/PlatformDeviceControl.c
+++ b/pc/PlatformDeviceControl.c
@@ -93,7 +93,7 @@ void XLinkPlatformInit()
 }
 
 
-int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
+int XLinkPlatformBootRemote(const deviceDesc_t* deviceDesc, const char* binaryPath)
 {
     FILE *file;
     long file_size;
@@ -135,7 +135,7 @@ int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
     return 0;
 }
 
-int XLinkPlatformBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, size_t length) {
+int XLinkPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, size_t length) {
     if (deviceDesc->protocol == X_LINK_PCIE) {
         // Temporary open fd to boot device and then close it
         int* pcieFd = NULL;

--- a/pc/PlatformDeviceControl.c
+++ b/pc/PlatformDeviceControl.c
@@ -236,14 +236,22 @@ libusb_device_handle *usbLinkOpen(const char *path)
     libusb_device_handle *h = NULL;
     libusb_device *dev = NULL;
     double waittm = seconds() + statuswaittimeout;
+
+    // Change PID for bootloader device
+    int vid = DEFAULT_OPENVID;
+    int pid = DEFAULT_OPENPID;
+    if(strstr(path, "bootloader") != NULL) {
+        pid = DEFAULT_BOOTLOADER_PID;
+    }
+
     while(seconds() < waittm){
         int size = strlen(path);
 
 #if (!defined(_WIN32) && !defined(_WIN64))
         uint16_t  bcdusb = -1;
-        rc = usb_find_device_with_bcd(0, (char *)path, size, (void **)&dev, DEFAULT_OPENVID, DEFAULT_OPENPID, &bcdusb);
+        rc = usb_find_device_with_bcd(0, (char *)path, size, (void **)&dev, vid, pid, &bcdusb);
 #else
-        rc = usb_find_device(0, (char *)path, size, (void **)&dev, DEFAULT_OPENVID, DEFAULT_OPENPID);
+        rc = usb_find_device(0, (char *)path, size, (void **)&dev, vid, pid);
 #endif
         if(rc == USB_BOOT_SUCCESS)
             break;

--- a/pc/PlatformDeviceControl.c
+++ b/pc/PlatformDeviceControl.c
@@ -93,25 +93,61 @@ void XLinkPlatformInit()
 }
 
 
-int XLinkPlatformBootMemoryRemote(deviceDesc_t* deviceDesc, uint8_t* buffer, long size)
+int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
 {
-    int rc = 0;
-    long file_size = size;
-    void *image_buffer = (void *) buffer;
+    FILE *file;
+    long file_size;
 
+    char *image_buffer;
+
+    /* Open the mvcmd file */
+    file = fopen(binaryPath, "rb");
+
+    if(file == NULL) {
+        mvLog(MVLOG_ERROR, "Cannot open file by path: %s", binaryPath);
+        return -7;
+    }
+
+    fseek(file, 0, SEEK_END);
+    file_size = ftell(file);
+    rewind(file);
+    if(file_size <= 0 || !(image_buffer = (char*)malloc(file_size)))
+    {
+        mvLog(MVLOG_ERROR, "cannot allocate image_buffer. file_size = %ld", file_size);
+        fclose(file);
+        return -3;
+    }
+    if(fread(image_buffer, 1, file_size, file) != file_size)
+    {
+        mvLog(MVLOG_ERROR, "cannot read file to image_buffer");
+        fclose(file);
+        free(image_buffer);
+        return -7;
+    }
+    fclose(file);
+
+    if(XLinkPlatformBootFirmware(deviceDesc, image_buffer, file_size)) {
+        free(image_buffer);
+        return -1;
+    }
+
+    free(image_buffer);
+    return 0;
+}
+
+int XLinkPlatformBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, size_t length) {
     if (deviceDesc->protocol == X_LINK_PCIE) {
         // Temporary open fd to boot device and then close it
         int* pcieFd = NULL;
-        rc = pcie_init(deviceDesc->name, (void**)&pcieFd);
+        int rc = pcie_init(deviceDesc->name, (void**)&pcieFd);
         if (rc) {
             return rc;
         }
 #if (!defined(_WIN32) && !defined(_WIN64))
-        rc = pcie_boot_device(*(int*)pcieFd, image_buffer, file_size);
+        rc = pcie_boot_device(*(int*)pcieFd, firmware, length);
 #else
-        rc = pcie_boot_device(pcieFd, image_buffer, file_size);
+        rc = pcie_boot_device(pcieFd, firmware, length);
 #endif
-
         pcie_close(pcieFd); // Will not check result for now
         return rc;
     } else if (deviceDesc->protocol == X_LINK_USB_VSC) {
@@ -123,60 +159,17 @@ int XLinkPlatformBootMemoryRemote(deviceDesc_t* deviceDesc, uint8_t* buffer, lon
             printf("Path to your boot util is too long for the char array here!\n");
         }
         // Boot it
-        rc = usb_boot(deviceDesc->name, image_buffer, file_size);
+        int rc = usb_boot(deviceDesc->name, firmware, (unsigned)length);
 
-        if(!rc && usb_loglevel > 1) {
-            fprintf(stderr, "Boot successful, device address %s\n", deviceDesc->name);
+        if(!rc) {
+            mvLog(MVLOG_DEBUG, "Boot successful, device address %s", deviceDesc->name);
         }
         return rc;
     } else {
-        printf("Selected protocol not supported\n");
         return -1;
     }
 }
 
-int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath)
-{
-    int rc = 0;
-    FILE *file;
-    long file_size;
-
-    void *image_buffer;
-
-    /* Open the mvcmd file */
-    file = fopen(binaryPath, "rb");
-
-    if(file == NULL) {
-        if(usb_loglevel)
-            perror(binaryPath);
-        return -7;
-    }
-
-    fseek(file, 0, SEEK_END);
-    file_size = ftell(file);
-    rewind(file);
-    if(file_size <= 0 || !(image_buffer = (char*)malloc(file_size)))
-    {
-        if(usb_loglevel)
-            perror("buffer");
-        fclose(file);
-        return -3;
-    }
-    if(fread(image_buffer, 1, file_size, file) != file_size)
-    {
-        if(usb_loglevel)
-            perror(binaryPath);
-        fclose(file);
-        free(image_buffer);
-        return -7;
-    }
-    fclose(file);
-
-    rc = XLinkPlatformBootMemoryRemote(deviceDesc, image_buffer, file_size);
-    free(image_buffer);
-
-    return rc;
-}
 
 int XLinkPlatformConnect(const char* devPathRead, const char* devPathWrite, XLinkProtocol_t protocol, void** fd)
 {
@@ -245,7 +238,7 @@ libusb_device_handle *usbLinkOpen(const char *path)
     }
 
     while(seconds() < waittm){
-        int size = strlen(path);
+        int size = (int)strlen(path);
 
 #if (!defined(_WIN32) && !defined(_WIN64))
         uint16_t  bcdusb = -1;
@@ -266,7 +259,7 @@ libusb_device_handle *usbLinkOpen(const char *path)
     if (libusb_rc < 0)
     {
         if(last_open_dev_err[0])
-            fprintf(stderr, "%s\n", last_open_dev_err);
+            mvLog(MVLOG_DEBUG, "Last opened device name: %s", last_open_dev_err);
 
         usb_close_device(h);
         usb_free_device(dev);

--- a/pc/PlatformDeviceSearch.c
+++ b/pc/PlatformDeviceSearch.c
@@ -179,6 +179,7 @@ XLinkPlatform_t XLinkPlatformPidToPlatform(const int pid) {
 XLinkDeviceState_t XLinkPlatformPidToState(const int pid) {
     switch (pid) {
         case DEFAULT_OPENPID: return X_LINK_BOOTED;
+        case DEFAULT_BOOTLOADER_PID: return X_LINK_BOOTLOADER;
         case AUTO_PID: return X_LINK_ANY_STATE;
         default:       return X_LINK_UNBOOTED;
     }
@@ -203,13 +204,15 @@ int platformToPid(const XLinkPlatform_t platform, const XLinkDeviceState_t state
         }
     } else if (state == X_LINK_BOOTED) {
         return DEFAULT_OPENPID;
+    } else if(state == X_LINK_BOOTLOADER){ 
+        return DEFAULT_BOOTLOADER_PID;
     } else if (state == X_LINK_ANY_STATE) {
         switch (platform) {
             case X_LINK_MYRIAD_2:  return DEFAULT_UNBOOTPID_2150;
             case X_LINK_MYRIAD_X:  return DEFAULT_UNBOOTPID_2485;
             default:               return AUTO_PID;
         }
-    }
+    } 
 
     return AUTO_PID;
 }
@@ -281,6 +284,13 @@ xLinkPlatformErrorCode_t getUSBDeviceName(int index,
             return X_LINK_PLATFORM_ERROR;
         }
         pid = DEFAULT_OPENPID;
+        
+    } else if(state == X_LINK_BOOTLOADER){
+          if (in_deviceRequirements.platform != X_LINK_ANY_PLATFORM) {
+            mvLog(MVLOG_WARN, "Search specific platform for bootloader device unavailable");
+            return X_LINK_PLATFORM_ERROR;
+        }
+        pid = DEFAULT_BOOTLOADER_PID;
     } else {
         if (searchByName) {
             pid = get_pid_by_name(in_deviceRequirements.name);

--- a/pc/Win/include/win_synchapi.h
+++ b/pc/Win/include/win_synchapi.h
@@ -1,0 +1,35 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef WIN_SYNCHAPI
+#define WIN_SYNCHAPI
+
+#include "win_pthread.h"
+#include "synchapi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _pthread_condattr_t pthread_condattr_t;
+
+typedef struct
+{
+    CONDITION_VARIABLE _cv;
+}
+pthread_cond_t;
+
+int pthread_cond_init(pthread_cond_t* __cond, const pthread_condattr_t* __cond_attr);
+int pthread_cond_destroy(pthread_cond_t* __cond);
+
+int pthread_cond_timedwait(pthread_cond_t* __cond,
+    pthread_mutex_t* __mutex,
+    const struct timespec* __abstime);
+int pthread_cond_broadcast(pthread_cond_t* __cond);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WIN_MUTEX */

--- a/pc/Win/src/win_pthread.c
+++ b/pc/Win/src/win_pthread.c
@@ -110,7 +110,7 @@ int pthread_create(pthread_t *thread, pthread_attr_t *attr,
     if (attr)
     {
         thread->pthread_state = attr->pthread_state;
-        stack_size = attr->stack_size;
+        stack_size = (unsigned)attr->stack_size;
     }
 
     thread->handle = (HANDLE)_beginthreadex((void *)NULL, stack_size, _pthread_start_routine, thread, 0, NULL);

--- a/pc/Win/src/win_synchapi.c
+++ b/pc/Win/src/win_synchapi.c
@@ -1,0 +1,53 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "win_synchapi.h"
+
+int pthread_cond_init(pthread_cond_t* __cond, const pthread_condattr_t* __cond_attr)
+{
+    if (__cond == NULL) {
+        return ERROR_INVALID_HANDLE;
+    }
+
+    (void)__cond_attr;
+    InitializeConditionVariable(&__cond->_cv);
+    return 0;
+}
+
+int pthread_cond_destroy(pthread_cond_t* __cond)
+{
+    (void)__cond;
+    return 0;
+}
+
+int pthread_cond_timedwait(pthread_cond_t* __cond,
+    pthread_mutex_t* __mutex,
+    const struct timespec* __abstime) 
+{
+    if (__cond == NULL) {
+        return ERROR_INVALID_HANDLE;
+    }
+
+    long long msec = INFINITE;
+    if (__abstime != NULL) {
+        msec = __abstime->tv_sec * 1000 + __abstime->tv_nsec / 1000000;
+    }
+
+    // SleepConditionVariableCS returns bool=true on success.
+    if (SleepConditionVariableCS(&__cond->_cv, __mutex, (DWORD)msec))
+        return 0;
+
+    const int rc = (int)GetLastError();
+    return rc == ERROR_TIMEOUT ? ETIMEDOUT : rc;
+}
+
+int pthread_cond_broadcast(pthread_cond_t *__cond)
+{
+    if (__cond == NULL) {
+        return ERROR_INVALID_HANDLE;
+    }
+
+    WakeConditionVariable(&__cond->_cv);
+    return 0;
+}

--- a/pc/Win/src/win_usb.c
+++ b/pc/Win/src/win_usb.c
@@ -16,6 +16,8 @@
 #include <stdint.h>
 #include "win_usb.h"
 
+#define MVLOG_UNIT_NAME xLinkWinUsb
+#include "XLinkLog.h"
 #include "XLinkStringUtils.h"
 
 #define USB_DIR_OUT     0
@@ -85,7 +87,7 @@ static const char *format_win32_msg(DWORD errId) {
 
 static void wperror(const char *errmsg) {
     DWORD errId = GetLastError();
-    fprintf(stderr, "%s: System err %d\n", errmsg, errId);
+    mvLog(MVLOG_DEBUG, "%s: System err %d\n", errmsg, errId);
 }
 
 static void wstrerror(char *buff, const char *errmsg) {
@@ -462,7 +464,7 @@ int usb_bulk_write(usb_hwnd han, uint8_t ep, const void *buffer, size_t sz, uint
         if(last_bulk_errcode == ERROR_SEM_TIMEOUT)
             return USB_ERR_TIMEOUT;
         wperror("WinUsb_WritePipe");
-        printf("\nWinUsb_WritePipe failed with error:=%d\n", GetLastError());
+        mvLog(MVLOG_ERROR, "\nWinUsb_WritePipe failed with error:=%d\n", GetLastError());
         return USB_ERR_FAILED;
     }
     last_bulk_errcode = 0;

--- a/pc/protocols/pcie_host.c
+++ b/pc/protocols/pcie_host.c
@@ -158,7 +158,7 @@ int pcie_write(HANDLE fd, void * buf, size_t bufSize)
 
     Overlapped.hEvent = Event;
     ResetEvent(Overlapped.hEvent);
-    OutputCode = WriteFile(dev, buf, bufSize, NULL, &Overlapped);
+    OutputCode = WriteFile(dev, buf, (DWORD)bufSize, NULL, &Overlapped);
 
     if (OutputCode == FALSE) {
         if (GetLastError() == ERROR_IO_PENDING) {
@@ -235,7 +235,7 @@ int pcie_read(HANDLE fd, void * buf, size_t bufSize)
 
     Overlapped.hEvent = Event;
     ResetEvent(Overlapped.hEvent);
-    OutputCode = ReadFile(dev, buf, bufSize, NULL, &Overlapped);
+    OutputCode = ReadFile(dev, buf, (DWORD)bufSize, NULL, &Overlapped);
 
     if (OutputCode == FALSE) {
        if (GetLastError() == ERROR_IO_PENDING) {
@@ -533,9 +533,9 @@ pcieHostError_t pcie_reset_device(HANDLE fd)
 #endif
 
 #if !defined(_WIN32)
-pcieHostError_t pcie_boot_device(int fd, void *buffer, size_t length)
+pcieHostError_t pcie_boot_device(int fd, const char *buffer, size_t length)
 #else
-pcieHostError_t pcie_boot_device(HANDLE fd, void *buffer, size_t length)
+pcieHostError_t pcie_boot_device(HANDLE fd, const char  *buffer, size_t length)
 #endif
 {
     ASSERT_XLINK_PLATFORM_R(fd, PCIE_INVALID_PARAMETERS);
@@ -583,7 +583,7 @@ pcieHostError_t pcie_boot_device(HANDLE fd, void *buffer, size_t length)
 
     bResult = DeviceIoControl(fd,                    // device to be queried
                               MXLK_BOOT_DEV,                 // operation to perform
-                              buffer, length,
+                              (void*)buffer, (DWORD)length,
                               &output_buffer, sizeof(output_buffer), // output buffer
                               &junk,                         // # bytes returned
                               (LPOVERLAPPED) NULL);          // synchronous I/O

--- a/pc/protocols/pcie_host.h
+++ b/pc/protocols/pcie_host.h
@@ -41,11 +41,11 @@ pcieHostError_t pcie_init(const char *slot, void **fd);
 pcieHostError_t pcie_close(void *fd);
 
 #if (!defined(_WIN32))
-pcieHostError_t pcie_boot_device(int fd, void *buffer, size_t length);
+pcieHostError_t pcie_boot_device(int fd, const char  *buffer, size_t length);
 pcieHostError_t pcie_reset_device(int fd);
 
 #else // Windows
-pcieHostError_t pcie_boot_device(HANDLE fd, void *buffer, size_t length);
+pcieHostError_t pcie_boot_device(HANDLE fd, const char  *buffer, size_t length);
 pcieHostError_t pcie_reset_device(HANDLE fd);
 #endif
 

--- a/pc/protocols/usb_boot.c
+++ b/pc/protocols/usb_boot.c
@@ -192,7 +192,7 @@ static int isBootedMyriadDevice(const int idVendor, const int idProduct) {
     return 0;
 }
 
-static isBootloaderMyriadDevice(const int idVendor, const int idProduct) {
+static int isBootloaderMyriadDevice(const int idVendor, const int idProduct) {
     // Device is Myriad and in bootloader
     if (idVendor == DEFAULT_OPENVID && idProduct == DEFAULT_BOOTLOADER_PID)
         return 1;

--- a/pc/protocols/usb_boot.c
+++ b/pc/protocols/usb_boot.c
@@ -33,6 +33,9 @@
 #define DEFAULT_SEND_FILE_TIMEOUT   10000
 #define USB1_CHUNKSZ                64
 
+#define MVLOG_UNIT_NAME xLinkUsb
+#include "XLinkLog.h"
+
 /*
  * ADDRESS_BUFF_SIZE 35 = 4*7+7.
  * '255-' x 7 (also gives us nul-terminator for last entry)
@@ -53,10 +56,12 @@ typedef struct {
 } deviceBootInfo_t;
 
 static deviceBootInfo_t supportedDevices[] = {
+#if 0 // Myriad 2 device has been deprecated since 2020.4 release
     {
         .pid = 0x2150,
         .name = "ma2450"
     },
+#endif
     {
         .pid = 0x2485,
         .name = "ma2480"
@@ -74,7 +79,6 @@ static deviceBootInfo_t supportedDevices[] = {
 // for now we'll only use the loglevel for usb boot. can bring it into
 // the rest of usblink later
 // use same levels as mvnc_loglevel for now
-int usb_loglevel = 0;
 #if (defined(_WIN32) || defined(_WIN64) )
 void initialize_usb_boot()
 {
@@ -127,9 +131,6 @@ static const char *get_pid_name(int pid)
             return supportedDevices[i].name;
     }
 
-    if(usb_loglevel)
-        fprintf(stderr, "%s(): Error pid:=%i not supported\n", __func__, pid);
-
     return NULL;
 }
 
@@ -142,10 +143,7 @@ int get_pid_by_name(const char* name)
 {
     char* p = strchr(name, '-');
     if (p == NULL) {
-        if (usb_loglevel) {
-            fprintf(stderr, "%s(): Error name (%s) not supported\n", __func__, name);
-        }
-
+        mvLog(MVLOG_DEBUG, "Device name (%s) not supported", name);
         return -1;
     }
     p++; //advance to point to the name
@@ -269,7 +267,7 @@ static pthread_mutex_t globalMutex = PTHREAD_MUTEX_INITIALIZER;
 usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
                                         unsigned addrsize, void **device, int vid, int pid, uint16_t* bcdusb) {
     if (pthread_mutex_lock(&globalMutex)) {
-        fprintf(stderr, "Mutex lock failed\n");
+        mvLog(MVLOG_ERROR, "globalMutex lock failed");
         return USB_BOOT_ERROR;
     }
     int searchByName = 0;
@@ -281,10 +279,9 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
     int res;
 
     if (!initialized) {
-        if (usb_loglevel)
-            fprintf(stderr, "Library has not been initialized when loaded\n");
+        mvLog(MVLOG_ERROR, "Library has not been initialized when loaded");
         if (pthread_mutex_unlock(&globalMutex)) {
-            fprintf(stderr, "Mutex unlock failed\n");
+            mvLog(MVLOG_ERROR, "globalMutex unlock failed");
         }
         return USB_BOOT_ERROR;
     }
@@ -300,10 +297,9 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
             devs = 0;
         }
         if ((res = libusb_get_device_list(NULL, &devs)) < 0) {
-            if (usb_loglevel)
-                fprintf(stderr, "Unable to get USB device list: %s\n", libusb_strerror(res));
+            mvLog(MVLOG_DEBUG, "Unable to get USB device list: %s", libusb_strerror(res));
             if (pthread_mutex_unlock(&globalMutex)) {
-                fprintf(stderr, "Mutex unlock failed\n");
+                mvLog(MVLOG_ERROR, "globalMutex unlock failed");
             }
             return USB_BOOT_ERROR;
         }
@@ -313,8 +309,7 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
     i = 0;
     while ((dev = devs[i++]) != NULL) {
         if ((res = libusb_get_device_descriptor(dev, &desc)) < 0) {
-            if (usb_loglevel)
-                fprintf(stderr, "Unable to get USB device descriptor: %s\n", libusb_strerror(res));
+            mvLog(MVLOG_DEBUG, "Unable to get USB device descriptor: %s", libusb_strerror(res));
             continue;
         }
 
@@ -339,10 +334,10 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
             if (device) {
                 const char *dev_addr = gen_addr(dev, get_pid_by_name(input_addr));
                 if (!strcmp(dev_addr, input_addr)) {
-                    if (usb_loglevel > 1) {
-                        fprintf(stderr, "Found Address: %s - VID/PID %04x:%04x\n",
-                                input_addr, desc.idVendor, desc.idProduct);
-                    }
+#if 0 // To avoid spam in Debug mode
+                    mvLog(MVLOG_DEBUG, "Found Address: %s - VID/PID %04x:%04x",
+                          input_addr, desc.idVendor, desc.idProduct);
+#endif
 
                     libusb_ref_device(dev);
                     libusb_free_device_list(devs, 1);
@@ -352,7 +347,7 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
                     devs = 0;
 
                     if (pthread_mutex_unlock(&globalMutex)) {
-                        fprintf(stderr, "Mutex unlock failed\n");
+                        mvLog(MVLOG_ERROR, "globalMutex unlock failed");
                     }
                     return USB_BOOT_SUCCESS;
                 }
@@ -360,24 +355,25 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
                 const char *dev_addr = gen_addr(dev, desc.idProduct);
                 // If the same add as input
                 if (!strcmp(dev_addr, input_addr)) {
-                    if (usb_loglevel > 1) {
-                        fprintf(stderr, "Found Address: %s - VID/PID %04x:%04x\n",
-                                input_addr, desc.idVendor, desc.idProduct);
-                    }
+#if 0 // To avoid spam in Debug mode
+                    mvLog(MVLOG_DEBUG, "Found Address: %s - VID/PID %04x:%04x",
+                          input_addr, desc.idVendor, desc.idProduct);
+#endif
 
                     if (pthread_mutex_unlock(&globalMutex)) {
-                        fprintf(stderr, "Mutex unlock failed\n");
+                        mvLog(MVLOG_ERROR, "globalMutex unlock failed");
                     }
                     return USB_BOOT_SUCCESS;
                 }
             } else if (idx == count) {
                 const char *caddr = gen_addr(dev, desc.idProduct);
-                if (usb_loglevel > 1)
-                    fprintf(stderr, "Device %d Address: %s - VID/PID %04x:%04x\n",
-                            idx, caddr, desc.idVendor, desc.idProduct);
+#if 0 // To avoid spam in Debug mode
+                mvLog(MVLOG_DEBUG, "Device %d Address: %s - VID/PID %04x:%04x",
+                      idx, caddr, desc.idVendor, desc.idProduct);
+#endif
                 mv_strncpy(input_addr, addrsize, caddr, addrsize - 1);
                 if (pthread_mutex_unlock(&globalMutex)) {
-                    fprintf(stderr, "Mutex unlock failed\n");
+                    mvLog(MVLOG_ERROR, "globalMutex unlock failed");
                 }
                 return USB_BOOT_SUCCESS;
             }
@@ -387,7 +383,7 @@ usbBootError_t usb_find_device_with_bcd(unsigned idx, char *input_addr,
     libusb_free_device_list(devs, 1);
     devs = 0;
     if (pthread_mutex_unlock(&globalMutex)) {
-        fprintf(stderr, "Mutex unlock failed\n");
+        mvLog(MVLOG_ERROR, "globalMutex unlock failed");
     }
     return USB_BOOT_DEVICE_NOT_FOUND;
 }
@@ -415,15 +411,13 @@ usbBootError_t usb_find_device(unsigned idx, char *addr, unsigned addrsize, void
 
     if(!initialized)
     {
-        if(usb_loglevel)
-            fprintf(stderr, "Library has not been initialized when loaded\n");
+        mvLog(MVLOG_ERROR, "Library has not been initialized when loaded");
         return USB_BOOT_ERROR;
     }
     if (devs_cnt == 0 || idx == 0) {
         devs_cnt = 0;
         if (((res = usb_list_devices(vid, pid, devs)) < 0)) {
-            if (usb_loglevel)
-                fprintf(stderr, "Unable to get USB device list: %s\n", libusb_strerror(res));
+            mvLog(MVLOG_DEBUG, "Unable to get USB device list: %s", libusb_strerror(res));
             return USB_BOOT_ERROR;
         }
         devs_cnt = res;
@@ -458,8 +452,7 @@ usbBootError_t usb_find_device(unsigned idx, char *addr, unsigned addrsize, void
                 const char *caddr = &devs[res][4];
                 if (strncmp(addr, caddr, XLINK_MAX_NAME_SIZE) == 0)
                 {
-                    if (usb_loglevel > 1)
-                        fprintf(stderr, "Found Address: %s - VID/PID %04x:%04x\n", caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
+                    mvLog(MVLOG_DEBUG, "Found Address: %s - VID/PID %04x:%04x", caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
                     *device = enumerate_usb_device(vid, pid, caddr, 0);
                     devs_cnt = 0;
                     return USB_BOOT_SUCCESS;
@@ -469,16 +462,14 @@ usbBootError_t usb_find_device(unsigned idx, char *addr, unsigned addrsize, void
                 const char *caddr = &devs[res][4];
                 if (strncmp(addr, caddr, XLINK_MAX_NAME_SIZE) == 0)
                 {
-                    if (usb_loglevel > 1)
-                        fprintf(stderr, "Found Address: %s - VID/PID %04x:%04x\n", caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
+                    mvLog(MVLOG_DEBUG, "Found Address: %s - VID/PID %04x:%04x", caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
                     return USB_BOOT_SUCCESS;
                 }
             }
             else if (idx == count)
             {
                 const char *caddr = &devs[res][4];
-                if (usb_loglevel > 1)
-                    fprintf(stderr, "Device %d Address: %s - VID/PID %04x:%04x\n", idx, caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
+                mvLog(MVLOG_DEBUG, "Device %d Address: %s - VID/PID %04x:%04x", idx, caddr, (int)(devs[res][0] << 8 | devs[res][1]), (int)(devs[res][2] << 8 | devs[res][3]));
                 mv_strncpy(addr, addrsize, caddr, addrsize - 1);
                 return USB_BOOT_SUCCESS;
             }
@@ -525,9 +516,8 @@ static libusb_device_handle *usb_open_device(libusb_device *dev, uint8_t *endpoi
     ifdesc = cdesc->interface->altsetting;
     for(i=0; i<ifdesc->bNumEndpoints; i++)
     {
-        if(usb_loglevel > 1)
-            fprintf(stderr, "Found EP 0x%02x : max packet size is %u bytes\n",
-                    ifdesc->endpoint[i].bEndpointAddress, ifdesc->endpoint[i].wMaxPacketSize);
+        mvLog(MVLOG_DEBUG, "Found EP 0x%02x : max packet size is %u bytes",
+              ifdesc->endpoint[i].bEndpointAddress, ifdesc->endpoint[i].wMaxPacketSize);
         if((ifdesc->endpoint[i].bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) != LIBUSB_TRANSFER_TYPE_BULK)
             continue;
         if( !(ifdesc->endpoint[i].bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) )
@@ -564,20 +554,19 @@ static int wait_findopen(const char *device_address, int timeout, libusb_device 
     }
 
     usleep(100000);
-    if(usb_loglevel > 1)
-    {
-        if(timeout == -1)
-            fprintf(stderr, "Starting wait for connect, no timeout\n");
-        else if(timeout == 0)
-            fprintf(stderr, "Trying to connect\n");
-        else fprintf(stderr, "Starting wait for connect with %ums timeout\n", timeout);
-    }
+
+    if(timeout == -1)
+        mvLog(MVLOG_DEBUG, "Starting wait for connect, no timeout");
+    else if(timeout == 0)
+        mvLog(MVLOG_DEBUG, "Trying to connect");
+    else mvLog(MVLOG_DEBUG, "Starting wait for connect with %ums timeout", timeout);
+
     last_open_dev_err[0] = 0;
     i = 0;
     for(;;)
     {
         highres_gettime(&t1);
-        int addr_size = strlen(device_address);
+        int addr_size = (int)strlen(device_address);
 #if (!defined(_WIN32) && !defined(_WIN64) )
         rc = usb_find_device_with_bcd(0, (char*)device_address, addr_size, (void**)dev,
                                       DEFAULT_VID, get_pid_by_name(device_address), bcdusb);
@@ -596,8 +585,7 @@ static int wait_findopen(const char *device_address, int timeout, libusb_device 
 #endif
             if(*devh != NULL)
             {
-                if(usb_loglevel > 1)
-                    fprintf(stderr, "Found and opened device\n");
+                mvLog(MVLOG_DEBUG, "Found and opened device");
                 return 0;
             }
 #if (!defined(_WIN32) && !defined(_WIN64) )
@@ -610,12 +598,9 @@ static int wait_findopen(const char *device_address, int timeout, libusb_device 
 
         if(timeout != -1)
         {
-            if(usb_loglevel)
-            {
-                if(last_open_dev_err[0])
-                    fprintf(stderr, "%s", last_open_dev_err);
-                fprintf(stderr, "error: device not found!\n");
-            }
+            if(last_open_dev_err[0])
+                mvLog(MVLOG_DEBUG, "Last opened device name: %s", last_open_dev_err);
+
             return rc ? USB_BOOT_DEVICE_NOT_FOUND : USB_BOOT_TIMEOUT;
         } else if (elapsedTime > (double)timeout) {
             return rc ? USB_BOOT_DEVICE_NOT_FOUND : USB_BOOT_TIMEOUT;
@@ -648,8 +633,7 @@ static int send_file(libusb_device_handle *h, uint8_t endpoint, const uint8_t *t
         bulk_chunklen = USB1_CHUNKSZ;
     }
 #endif
-    if(usb_loglevel > 1)
-        fprintf(stderr, "Performing bulk write of %u bytes...\n", filesize);
+    mvLog(MVLOG_DEBUG, "Performing bulk write of %u bytes...", filesize);
     while(((unsigned)twb < filesize) || send_zlp)
     {
         highres_gettime(&t1);
@@ -662,14 +646,11 @@ static int send_file(libusb_device_handle *h, uint8_t endpoint, const uint8_t *t
 #else
         rc = usb_bulk_write(h, endpoint, (void *)p, wb, &wbr, write_timeout);
 #endif
-        if(usb_loglevel)
-            fprintf(stderr, " -write %d, written %d, status %s\n", wb, wbr, libusb_strerror(rc));
         if((rc || (wb != wbr)) && (wb != 0)) // Don't check the return code for ZLP
         {
             if(rc == LIBUSB_ERROR_NO_DEVICE)
                 break;
-            if(usb_loglevel)
-                fprintf(stderr, "bulk write: %s (%d bytes written, %d bytes to write)\n", libusb_strerror(rc), wbr, wb);
+            mvLog(MVLOG_WARN, "bulk write: %s (%d bytes written, %d bytes to write)", libusb_strerror(rc), wbr, wb);
             if(rc == LIBUSB_ERROR_TIMEOUT)
                 return USB_BOOT_TIMEOUT;
             else return USB_BOOT_ERROR;
@@ -684,11 +665,12 @@ static int send_file(libusb_device_handle *h, uint8_t endpoint, const uint8_t *t
         twb += wbr;
         p += wbr;
     }
-    if(usb_loglevel > 1)
-    {
-        double MBpS = ((double)filesize / 1048576.) / (elapsedTime * 0.001);
-        fprintf(stderr, "Successfully sent %u bytes of data in %lf ms (%lf MB/s)\n", filesize, elapsedTime, MBpS);
-    }
+
+#ifndef NDEBUG
+    double MBpS = ((double)filesize / 1048576.) / (elapsedTime * 0.001);
+    mvLog(MVLOG_DEBUG, "Successfully sent %u bytes of data in %lf ms (%lf MB/s)", filesize, elapsedTime, MBpS);
+#endif
+
     return 0;
 }
 

--- a/pc/protocols/usb_boot.c
+++ b/pc/protocols/usb_boot.c
@@ -452,7 +452,7 @@ usbBootError_t usb_find_device(unsigned idx, char *addr, unsigned addrsize, void
                         && isBootedMyriadDevice(idVendor, idProduct))
                 // Any bootloader device
                 || (vid == AUTO_VID && pid == DEFAULT_BOOTLOADER_PID
-                    && isBootloaderMyriadDevice(desc.idVendor, desc.idProduct)) 
+                    && isBootloaderMyriadDevice(idVendor, idProduct)) 
         ) {
             if (device) {
                 const char *caddr = &devs[res][4];

--- a/pc/protocols/usb_boot.h
+++ b/pc/protocols/usb_boot.h
@@ -6,8 +6,6 @@
 extern "C" {
 #endif
 
-extern int usb_loglevel;
-
 #define AUTO_VID                    0
 #define AUTO_PID                    0
 #define AUTO_UNBOOTED_PID           -1

--- a/pc/protocols/usb_boot.h
+++ b/pc/protocols/usb_boot.h
@@ -21,6 +21,7 @@ extern int usb_loglevel;
 #define DEFAULT_UNBOOTVID           0x03E7
 #define DEFAULT_UNBOOTPID_2485      0x2485
 #define DEFAULT_UNBOOTPID_2150      0x2150
+#define DEFAULT_BOOTLOADER_PID      0xf63c
 #define DEFAULT_CHUNKSZ             1024*1024
 
 

--- a/shared/include/XLink.h
+++ b/shared/include/XLink.h
@@ -81,7 +81,7 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler);
  * @param size - size of buffer
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
-XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size);
+XLinkError_t XLinkBootMemory(const deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size);
 
 /**
  * @brief Boots specified firmware binary to the remote device
@@ -89,7 +89,7 @@ XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, un
  * @param binaryPath - path to the *.mvcmd file
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
-XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath);
+XLinkError_t XLinkBoot(const deviceDesc_t* deviceDesc, const char* binaryPath);
 
 /**
  * @brief Boots specified firmware binary to the remote device
@@ -98,7 +98,7 @@ XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath);
  * @param length - firmware buffer length
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
-XLinkError_t XLinkBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, unsigned long length);
+XLinkError_t XLinkBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, unsigned long length);
 
 /**
  * @brief Resets the remote device and close all open local handles for this device

--- a/shared/include/XLink.h
+++ b/shared/include/XLink.h
@@ -81,7 +81,7 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler);
  * @param size - size of buffer
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
-XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, uint8_t* buffer, long size);
+XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size);
 
 /**
  * @brief Boots specified firmware binary to the remote device
@@ -90,6 +90,15 @@ XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, uint8_t* buffer, long siz
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
 XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath);
+
+/**
+ * @brief Boots specified firmware binary to the remote device
+ * @param deviceDesc - device description structure, obtained from XLinkFind* functions call
+ * @param firmware - firmware buffer
+ * @param length - firmware buffer length
+ * @return Status code of the operation: X_LINK_SUCCESS (0) for success
+ */
+XLinkError_t XLinkBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, unsigned long length);
 
 /**
  * @brief Resets the remote device and close all open local handles for this device

--- a/shared/include/XLinkLog.h
+++ b/shared/include/XLinkLog.h
@@ -86,7 +86,7 @@ inline void mvLogLevelSet(mvLog_t lvl){
 // Set the global log level. Can be used to prevent modules from hiding messages (enable all of them with a single change)
 // This should be an application setting, not a per module one
 inline void mvLogDefaultLevelSet(mvLog_t lvl){
-    if(lvl < MVLOG_LAST){
+    if(lvl <= MVLOG_LAST){
         MVLOGLEVEL(default) = lvl;
     }
 }

--- a/shared/include/XLinkLog.h
+++ b/shared/include/XLinkLog.h
@@ -30,81 +30,6 @@
 #define _GNU_SOURCE
 #endif
 
-#if (defined (WINNT) || defined(_WIN32) || defined(_WIN64) )
-#include "win_pthread.h"
-#else
-#ifndef __shave__	// SHAVE does not support threads
-#include <pthread.h>
-#endif
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-#ifndef __shave__	// SHAVE does not support threads
-extern int pthread_getname_np (pthread_t , char *, size_t);
-#endif
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __RTEMS__
-#include <rtems.h>
-#include <rtems/bspIo.h>
-#endif
-
-// Windows-only
-#if (defined (WINNT) || defined(_WIN32) || defined(_WIN64) )
-#define __attribute__(x)
-#define FUNCATTR_WEAK static
-#else
-#define FUNCATTR_WEAK
-#endif
-
-#ifndef MVLOG_UNIT_NAME
-#define MVLOG_UNIT_NAME global
-#endif
-
-#define _MVLOGLEVEL(UNIT_NAME)  mvLogLevel_ ## UNIT_NAME
-#define  MVLOGLEVEL(UNIT_NAME) _MVLOGLEVEL(UNIT_NAME)
-
-#define MVLOG_STR(x) _MVLOG_STR(x)
-#define _MVLOG_STR(x)  #x
-
-#define UNIT_NAME_STR MVLOG_STR(MVLOG_UNIT_NAME)
-
-#define ANSI_COLOR_RED     "\x1b[31m"
-#define ANSI_COLOR_GREEN   "\x1b[32m"
-#define ANSI_COLOR_YELLOW  "\x1b[33m"
-#define ANSI_COLOR_BLUE    "\x1b[34m"
-#define ANSI_COLOR_MAGENTA "\x1b[35m"
-#define ANSI_COLOR_CYAN    "\x1b[36m"
-#define ANSI_COLOR_WHITE   "\x1b[37m"
-#define ANSI_COLOR_RESET   "\x1b[0m"
-
-#ifndef MVLOG_DEBUG_COLOR
-#define MVLOG_DEBUG_COLOR ANSI_COLOR_WHITE
-#endif
-
-#ifndef MVLOG_INFO_COLOR
-#define MVLOG_INFO_COLOR ANSI_COLOR_CYAN
-#endif
-
-#ifndef MVLOG_WARN_COLOR
-#define MVLOG_WARN_COLOR ANSI_COLOR_YELLOW
-#endif
-
-#ifndef MVLOG_ERROR_COLOR
-#define MVLOG_ERROR_COLOR ANSI_COLOR_MAGENTA
-#endif
-
-#ifndef MVLOG_FATAL_COLOR
-#define MVLOG_FATAL_COLOR ANSI_COLOR_RED
-#endif
-
-#ifndef MVLOG_MAXIMUM_THREAD_NAME_SIZE
-#define MVLOG_MAXIMUM_THREAD_NAME_SIZE 16
-#endif
 
 typedef enum mvLog_t{
     MVLOG_DEBUG = 0,
@@ -115,95 +40,55 @@ typedef enum mvLog_t{
     MVLOG_LAST,
 } mvLog_t;
 
-#ifdef __shave__
-__attribute__((section(".laststage")))
-#endif
-static const char mvLogHeader[MVLOG_LAST][30] =
-    {
-        MVLOG_DEBUG_COLOR "D:",
-        MVLOG_INFO_COLOR  "I:",
-        MVLOG_WARN_COLOR  "W:",
-        MVLOG_ERROR_COLOR "E:",
-        MVLOG_FATAL_COLOR "F:"
-    };
-
-// #ifdef __shave__
-// __attribute__((section(".laststage")))
-// #endif
-FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG_LAST;
-
-// #ifdef __shave__
-// __attribute__((section(".laststage")))
-// #endif
-FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(default) = MVLOG_ERROR;
-
-#ifdef __shave__
-__attribute__((section(".laststage")))
-#endif
-static int __attribute__ ((unused))
-logprintf(enum mvLog_t lvl, const char * func, const int line,
-          const char * format, ...)
-{
-    if((MVLOGLEVEL(MVLOG_UNIT_NAME) == MVLOG_LAST && lvl < MVLOGLEVEL(default)))
-        return 0;
-
-    if((MVLOGLEVEL(MVLOG_UNIT_NAME) < MVLOG_LAST && lvl < MVLOGLEVEL(MVLOG_UNIT_NAME)))
-        return 0;
-
-    const char headerFormat[] = "%s [%s] [%10" PRId64 "] [%s] %s:%d\t";
-#ifdef __RTEMS__
-    uint64_t timestamp = rtems_clock_get_uptime_nanoseconds() / 1000;
-#elif !defined(_WIN32) && !(defined MA2450 || defined __shave__)
-    struct timespec spec;
-    clock_gettime(CLOCK_REALTIME, &spec);
-    uint64_t timestamp = (spec.tv_sec % 1000) * 1000 + spec.tv_nsec / 1e6;
+// Windows-only
+#if (defined (WINNT) || defined(_WIN32) || defined(_WIN64) )
+#define __attribute__(x)
+#define FUNCATTR_WEAK static
 #else
-    uint64_t timestamp = 0;
-#endif
-    va_list args;
-    va_start (args, format);
-
-    char threadName[MVLOG_MAXIMUM_THREAD_NAME_SIZE] = {0};
-#if defined MA2450 || defined __shave__
-    snprintf(threadName, sizeof(threadName), "ThreadName_N/A");
-#elif !defined(ANDROID)
-    pthread_getname_np(pthread_self(), threadName, sizeof(threadName));
+#define FUNCATTR_WEAK
 #endif
 
-#ifdef __RTEMS__
-    if(!rtems_interrupt_is_in_progress())
-    {
-#endif
-#if defined __sparc__ || defined __PC__
-    fprintf(stdout, headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
-    vfprintf(stdout, format, args);
-    fprintf(stdout, "%s\n", ANSI_COLOR_RESET);
-#elif defined __shave__
-    printf(headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
-    printf(format, args);
-    printf("%s\n", ANSI_COLOR_RESET);
+#define _MVLOGLEVEL(UNIT_NAME)  mvLogLevel_ ## UNIT_NAME
+#define  MVLOGLEVEL(UNIT_NAME) _MVLOGLEVEL(UNIT_NAME)
 
-#endif
-#ifdef __RTEMS__
-    }
-    else
-    {
-        printk(headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
-        vprintk(format, args);
-        printk("%s\n", ANSI_COLOR_RESET);
-    }
-#endif
-    va_end (args);
-    return 0;
-}
+#define MVLOG_STR(x) _MVLOG_STR(x)
+#define _MVLOG_STR(x)  #x
 
-#define mvLog(lvl, format, ...)                                 \
-    logprintf(lvl, __func__, __LINE__, format, ##__VA_ARGS__)
+#ifndef MVLOG_UNIT_NAME
+#define MVLOG_UNIT_NAME global
+#else
+FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG_LAST;
+#endif
+
+
+#ifndef MVLOG_MAXIMUM_THREAD_NAME_SIZE
+#define MVLOG_MAXIMUM_THREAD_NAME_SIZE 16
+#endif
+
+#define UNIT_NAME_STR MVLOG_STR(MVLOG_UNIT_NAME)
+
+
+extern mvLog_t MVLOGLEVEL(global);
+extern mvLog_t MVLOGLEVEL(default);
+
+int __attribute__ ((unused)) logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line, const char * format, ...);
+
+#define mvLog(lvl, format, ...)                              \
+    logprintf(MVLOGLEVEL(MVLOG_UNIT_NAME), lvl, __func__, __LINE__, format, ##__VA_ARGS__)
 
 // Set log level for the current unit. Note that the level must be smaller than the global default
-#define mvLogLevelSet(lvl) if(lvl < MVLOG_LAST){ MVLOGLEVEL(MVLOG_UNIT_NAME) = lvl; }
+inline void mvLogLevelSet(mvLog_t lvl){
+    if(lvl < MVLOG_LAST){
+        MVLOGLEVEL(MVLOG_UNIT_NAME) = lvl;
+    }
+}
+
 // Set the global log level. Can be used to prevent modules from hiding messages (enable all of them with a single change)
 // This should be an application setting, not a per module one
-#define mvLogDefaultLevelSet(lvl) if(lvl < MVLOG_LAST){ MVLOGLEVEL(default) = lvl; }
+inline void mvLogDefaultLevelSet(mvLog_t lvl){
+    if(lvl < MVLOG_LAST){
+        MVLOGLEVEL(default) = lvl;
+    }
+}
 
 #endif

--- a/shared/include/XLinkPlatform.h
+++ b/shared/include/XLinkPlatform.h
@@ -50,8 +50,8 @@ xLinkPlatformErrorCode_t XLinkPlatformFindArrayOfDevicesNames(
     const unsigned int devicesArraySize,
     unsigned int *out_amountOfFoundDevices);
 
-int XLinkPlatformBootMemoryRemote(deviceDesc_t* deviceDesc, uint8_t* buffer, long size);
 int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath);
+int XLinkPlatformBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, size_t length);
 int XLinkPlatformConnect(const char* devPathRead, const char* devPathWrite,
                          XLinkProtocol_t protocol, void** fd);
 #endif // __PC__

--- a/shared/include/XLinkPlatform.h
+++ b/shared/include/XLinkPlatform.h
@@ -50,8 +50,8 @@ xLinkPlatformErrorCode_t XLinkPlatformFindArrayOfDevicesNames(
     const unsigned int devicesArraySize,
     unsigned int *out_amountOfFoundDevices);
 
-int XLinkPlatformBootRemote(deviceDesc_t* deviceDesc, const char* binaryPath);
-int XLinkPlatformBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, size_t length);
+int XLinkPlatformBootRemote(const deviceDesc_t* deviceDesc, const char* binaryPath);
+int XLinkPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, size_t length);
 int XLinkPlatformConnect(const char* devPathRead, const char* devPathWrite,
                          XLinkProtocol_t protocol, void** fd);
 #endif // __PC__

--- a/shared/include/XLinkPublicDefines.h
+++ b/shared/include/XLinkPublicDefines.h
@@ -51,6 +51,7 @@ typedef enum{
     X_LINK_ANY_STATE = 0,
     X_LINK_BOOTED,
     X_LINK_UNBOOTED,
+    X_LINK_BOOTLOADER,
 } XLinkDeviceState_t;
 
 typedef enum{

--- a/shared/src/XLinkData.c
+++ b/shared/src/XLinkData.c
@@ -287,7 +287,7 @@ static XLinkError_t getLinkByStreamId(streamId_t streamId, xLinkDesc_t** out_lin
     linkId_t id = EXTRACT_LINK_ID(streamId);
     *out_link = getLinkById(id);
 
-    ASSERT_XLINK(*out_link != NULL);
+    XLINK_RET_ERR_IF(*out_link == NULL, X_LINK_ERROR);
     XLINK_RET_ERR_IF(getXLinkState(*out_link) != XLINK_UP,
                     X_LINK_COMMUNICATION_NOT_OPEN);
 

--- a/shared/src/XLinkDevice.c
+++ b/shared/src/XLinkDevice.c
@@ -216,7 +216,7 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
     return X_LINK_SUCCESS;
 }
 
-XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size)
+XLinkError_t XLinkBootMemory(const deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size)
 {
     if (XLinkPlatformBootFirmware(deviceDesc, (const char*) buffer, size) == 0) {
         return X_LINK_SUCCESS;
@@ -225,7 +225,7 @@ XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, un
     return X_LINK_COMMUNICATION_FAIL;
 }
 
-XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath)
+XLinkError_t XLinkBoot(const deviceDesc_t* deviceDesc, const char* binaryPath)
 {
     if (XLinkPlatformBootRemote(deviceDesc, binaryPath) == 0) {
         return X_LINK_SUCCESS;
@@ -234,7 +234,7 @@ XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath)
     return X_LINK_COMMUNICATION_FAIL;
 }
 
-XLinkError_t XLinkBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, unsigned long length) {
+XLinkError_t XLinkBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, unsigned long length) {
     if (!XLinkPlatformBootFirmware(deviceDesc, firmware, length)) {
         return X_LINK_SUCCESS;
     }

--- a/shared/src/XLinkDevice.c
+++ b/shared/src/XLinkDevice.c
@@ -216,9 +216,9 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
     return X_LINK_SUCCESS;
 }
 
-XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, uint8_t* buffer, long size)
+XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, const uint8_t* buffer, unsigned long size)
 {
-    if (XLinkPlatformBootMemoryRemote(deviceDesc, buffer, size) == 0) {
+    if (XLinkPlatformBootFirmware(deviceDesc, (const char*) buffer, size) == 0) {
         return X_LINK_SUCCESS;
     }
 
@@ -228,6 +228,14 @@ XLinkError_t XLinkBootMemory(deviceDesc_t* deviceDesc, uint8_t* buffer, long siz
 XLinkError_t XLinkBoot(deviceDesc_t* deviceDesc, const char* binaryPath)
 {
     if (XLinkPlatformBootRemote(deviceDesc, binaryPath) == 0) {
+        return X_LINK_SUCCESS;
+    }
+
+    return X_LINK_COMMUNICATION_FAIL;
+}
+
+XLinkError_t XLinkBootFirmware(deviceDesc_t* deviceDesc, const char* firmware, unsigned long length) {
+    if (!XLinkPlatformBootFirmware(deviceDesc, firmware, length)) {
         return X_LINK_SUCCESS;
     }
 

--- a/shared/src/XLinkLog.c
+++ b/shared/src/XLinkLog.c
@@ -1,0 +1,174 @@
+// Copyright (C) 2018-2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/*
+ * Add logging capabilities over simple printf.
+ * Allows 5 different logging levels:
+ *
+ * MVLOG_DEBUG = 0
+ * MVLOG_INFO = 1
+ * MVLOG_WARN = 2
+ * MVLOG_ERROR = 3
+ * MVLOG_FATAL = 4
+ * Before including header, a unit name can be set, otherwise defaults to global. eg:
+ *
+ * #define MVLOG_UNIT_NAME unitname
+ * #include <mvLog.h>
+ * Setting log level through debugger can be done in the following way:
+ * mset mvLogLevel_unitname 2
+ * Will set log level to warnings and above
+ */
+
+#include "XLinkLog.h"
+
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <inttypes.h>
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#if (defined (WINNT) || defined(_WIN32) || defined(_WIN64) )
+#include "win_pthread.h"
+#else
+#ifndef __shave__	// SHAVE does not support threads
+#include <pthread.h>
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifndef __shave__	// SHAVE does not support threads
+extern int pthread_getname_np (pthread_t , char *, size_t);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __RTEMS__
+#include <rtems.h>
+#include <rtems/bspIo.h>
+#endif
+
+
+#define MVLOG_STR(x) _MVLOG_STR(x)
+#define _MVLOG_STR(x)  #x
+
+#define UNIT_NAME_STR MVLOG_STR(MVLOG_UNIT_NAME)
+
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_BLUE    "\x1b[34m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_CYAN    "\x1b[36m"
+#define ANSI_COLOR_WHITE   "\x1b[37m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
+#ifndef MVLOG_DEBUG_COLOR
+#define MVLOG_DEBUG_COLOR ANSI_COLOR_WHITE
+#endif
+
+#ifndef MVLOG_INFO_COLOR
+#define MVLOG_INFO_COLOR ANSI_COLOR_CYAN
+#endif
+
+#ifndef MVLOG_WARN_COLOR
+#define MVLOG_WARN_COLOR ANSI_COLOR_YELLOW
+#endif
+
+#ifndef MVLOG_ERROR_COLOR
+#define MVLOG_ERROR_COLOR ANSI_COLOR_MAGENTA
+#endif
+
+#ifndef MVLOG_FATAL_COLOR
+#define MVLOG_FATAL_COLOR ANSI_COLOR_RED
+#endif
+
+
+#ifdef __shave__
+__attribute__((section(".laststage")))
+#endif
+static const char mvLogHeader[MVLOG_LAST][30] =
+    {
+        MVLOG_DEBUG_COLOR "D:",
+        MVLOG_INFO_COLOR  "I:",
+        MVLOG_WARN_COLOR  "W:",
+        MVLOG_ERROR_COLOR "E:",
+        MVLOG_FATAL_COLOR "F:"
+    };
+
+
+// Define global and default
+mvLog_t MVLOGLEVEL(global) = MVLOG_LAST;
+mvLog_t MVLOGLEVEL(default) = MVLOG_ERROR;
+
+void XLinkLogGetThreadName(char *buf, size_t len);
+
+void XLinkLogGetThreadName(char *buf, size_t len){
+    pthread_getname_np(pthread_self(), buf, len);
+}
+
+#ifdef __shave__
+__attribute__((section(".laststage")))
+#endif
+int __attribute__ ((unused))
+logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line,
+          const char * format, ...)
+{
+    if((curLogLvl == MVLOG_LAST && lvl < MVLOGLEVEL(default)))
+        return 0;
+
+    if((curLogLvl < MVLOG_LAST && lvl < curLogLvl))
+        return 0;
+
+    const char headerFormat[] = "%s [%s] [%10" PRId64 "] [%s] %s:%d\t";
+#ifdef __RTEMS__
+    uint64_t timestamp = rtems_clock_get_uptime_nanoseconds() / 1000;
+#elif !defined(_WIN32) && !(defined MA2450 || defined __shave__)
+    struct timespec spec;
+    clock_gettime(CLOCK_REALTIME, &spec);
+    uint64_t timestamp = (spec.tv_sec % 1000) * 1000 + spec.tv_nsec / 1e6;
+#else
+    uint64_t timestamp = 0;
+#endif
+    va_list args;
+    va_start (args, format);
+
+    char threadName[MVLOG_MAXIMUM_THREAD_NAME_SIZE] = {0};
+#if defined MA2450 || defined __shave__
+    snprintf(threadName, sizeof(threadName), "ThreadName_N/A");
+#elif !defined(ANDROID)
+    XLinkLogGetThreadName(threadName, sizeof(threadName));
+#endif
+
+#ifdef __RTEMS__
+    if(!rtems_interrupt_is_in_progress())
+    {
+#endif
+#if defined __sparc__ || defined __PC__
+    fprintf(stdout, headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
+    vfprintf(stdout, format, args);
+    fprintf(stdout, "%s\n", ANSI_COLOR_RESET);
+#elif defined __shave__
+    printf(headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
+    printf(format, args);
+    printf("%s\n", ANSI_COLOR_RESET);
+
+#endif
+#ifdef __RTEMS__
+    }
+    else
+    {
+        printk(headerFormat, mvLogHeader[lvl], UNIT_NAME_STR, timestamp, threadName, func, line);
+        vprintk(format, args);
+        printk("%s\n", ANSI_COLOR_RESET);
+    }
+#endif
+    va_end (args);
+    return 0;
+}


### PR DESCRIPTION
This PR adds the following changes to XLink:
 - bootloader support (added new device, with a custom name: '[path]-bootloader')
 - upstream XLink changes from openvino (most of diff is changing direct prints to mvLog)
 - XLinkLog: support for Windows (setting mvLogDefaultLevel to MVLOG_LAST disables all messages on Windows as well)
 - Some const qualifier on public facing API
 - Added CI for Win, Mac and Linux for easier development