### PR TITLE
Stream desynchronization fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ project(${TARGET_NAME} LANGUAGES C CXX)
 include(XLink.cmake)
 
 # Add option - MX ID naming instead of usb port
-option(XLINK_USE_MX_ID_NAME "Use MX ID name instead of usb port" ON) 
+option(XLINK_USE_MX_ID_NAME "Use MX ID name instead of usb port" ON)
+# Build tests
+option(XLINK_BUILD_TESTS "Build XLink tests" OFF)
 
 add_library(${TARGET_NAME} ${XLINK_SOURCES})
 
@@ -25,7 +27,7 @@ endif()
 
 if(MINGW)
     target_link_libraries(${TARGET_NAME}
-        PUBLIC  
+        PUBLIC
             libwinusb.a
             libsetupapi.a
     )
@@ -48,7 +50,7 @@ target_compile_definitions(${TARGET_NAME}
         USE_USB_VSC
     PUBLIC
         __PC__
-        XLINK_USE_MX_ID_NAME=${XLINK_USE_MX_ID_NAME}    
+        XLINK_USE_MX_ID_NAME=${XLINK_USE_MX_ID_NAME}
 )
 
 if (ENABLE_MYRIAD_NO_BOOT)
@@ -58,6 +60,12 @@ if (ENABLE_MYRIAD_NO_BOOT)
 endif()
 
 set_property(TARGET ${TARGET_NAME} PROPERTY C_STANDARD 99)
+
+
+# Tests
+if(XLINK_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS ${TARGET_NAME}

--- a/shared/src/XLinkData.c
+++ b/shared/src/XLinkData.c
@@ -63,11 +63,6 @@ streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size)
         mv_strncpy(event.header.streamName, MAX_STREAM_NAME_LENGTH,
                    name, MAX_STREAM_NAME_LENGTH - 1);
 
-        // Create new streamId if HOST (host keeps track of unique streamIds)
-#ifdef __PC__
-        event.header.streamId = XLinkAddOrUpdateStream(link->deviceHandle.xLinkFD, event.header.streamName, stream_write_size, 0, INVALID_STREAM_ID);
-#endif
-
         DispatcherAddEvent(EVENT_LOCAL, &event);
         XLINK_RET_ERR_IF(
             DispatcherWaitEventComplete(&link->deviceHandle),

--- a/shared/src/XLinkData.c
+++ b/shared/src/XLinkData.c
@@ -63,6 +63,11 @@ streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size)
         mv_strncpy(event.header.streamName, MAX_STREAM_NAME_LENGTH,
                    name, MAX_STREAM_NAME_LENGTH - 1);
 
+        // Create new streamId if HOST (host keeps track of unique streamIds)
+#ifdef __PC__
+        event.header.streamId = XLinkAddOrUpdateStream(link->deviceHandle.xLinkFD, event.header.streamName, stream_write_size, 0, INVALID_STREAM_ID);
+#endif
+
         DispatcherAddEvent(EVENT_LOCAL, &event);
         XLINK_RET_ERR_IF(
             DispatcherWaitEventComplete(&link->deviceHandle),
@@ -373,7 +378,7 @@ XLinkError_t addEventWithPerfTimeout(xLinkEvent_t *event, float* opTime, unsigne
     absTimeout.tv_nsec += (msTimeout - sec) * 1000000;
     int64_t secOver = absTimeout.tv_nsec / 1000000000;
     absTimeout.tv_nsec -= secOver * 1000000000;
-    absTimeout.tv_sec += secOver; 
+    absTimeout.tv_sec += secOver;
 
     int rc = addEventTimeout(event, absTimeout);
     if(rc != X_LINK_SUCCESS) return rc;

--- a/shared/src/XLinkDispatcherImpl.c
+++ b/shared/src/XLinkDispatcherImpl.c
@@ -293,11 +293,18 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
         case XLINK_CREATE_STREAM_REQ:
             XLINK_EVENT_ACKNOWLEDGE(response);
             response->header.type = XLINK_CREATE_STREAM_RESP;
+
+            // If Device side, accept the stream id selected by host
+            streamId_t streamId = INVALID_LINK_ID;
+            #ifndef __PC__
+            streamId = event->header.streamId;
+            #endif
+
             //write size from remote means read size for this peer
             response->header.streamId = XLinkAddOrUpdateStream(event->deviceHandle.xLinkFD,
                                                                event->header.streamName,
                                                                0, event->header.size,
-                                                               INVALID_STREAM_ID);
+                                                               streamId);
 
             if (response->header.streamId == INVALID_STREAM_ID) {
                 response->header.flags.bitField.ack = 0;

--- a/shared/src/XLinkDispatcherImpl.c
+++ b/shared/src/XLinkDispatcherImpl.c
@@ -295,7 +295,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             response->header.type = XLINK_CREATE_STREAM_RESP;
 
             // If Device side, accept the stream id selected by host
-            streamId_t streamId = INVALID_LINK_ID;
+            streamId_t streamId = INVALID_STREAM_ID;
             #ifndef __PC__
             streamId = event->header.streamId;
             #endif

--- a/shared/src/XLinkDispatcherImpl.c
+++ b/shared/src/XLinkDispatcherImpl.c
@@ -176,6 +176,13 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
         }
         case XLINK_CREATE_STREAM_REQ:
         {
+
+            // If Host side - this event happens when host tries to send an OpenStream request to device.
+            // Generate a streamId (and not relly on device to do it) and send that to the device.
+            #ifdef __PC__
+                event->header.streamId = XLinkAddOrUpdateStream(event->deviceHandle.xLinkFD, event->header.streamName, event->header.size, 0, INVALID_STREAM_ID);
+            #endif
+
             XLINK_EVENT_ACKNOWLEDGE(event);
             mvLog(MVLOG_DEBUG,"XLINK_CREATE_STREAM_REQ - do nothing\n");
             break;
@@ -294,10 +301,12 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             XLINK_EVENT_ACKNOWLEDGE(response);
             response->header.type = XLINK_CREATE_STREAM_RESP;
 
-            // If Device side, accept the stream id selected by host
+            // If Host side, create its own stream id
+            #ifdef __PC__
             streamId_t streamId = INVALID_STREAM_ID;
-            #ifndef __PC__
-            streamId = event->header.streamId;
+            #else
+            // If Device side, accept the stream id selected by host
+            streamId_t streamId = event->header.streamId;
             #endif
 
             //write size from remote means read size for this peer

--- a/shared/src/XLinkDispatcherImpl.c
+++ b/shared/src/XLinkDispatcherImpl.c
@@ -178,7 +178,7 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
         {
 
             // If Host side - this event happens when host tries to send an OpenStream request to device.
-            // Generate a streamId (and not relly on device to do it) and send that to the device.
+            // Generate a streamId (and not rely on device to do it) and send that to the device.
             #ifdef __PC__
                 event->header.streamId = XLinkAddOrUpdateStream(event->deviceHandle.xLinkFD, event->header.streamName, event->header.size, 0, INVALID_STREAM_ID);
             #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Helper 'add_test'
+macro(add_test test_name test_src)
+    add_executable(${test_name} ${test_src})
+    target_link_libraries(${test_name} ${TARGET_NAME})
+    set_property(TARGET ${test_name} PROPERTY CXX_STANDARD 11)
+    set_property(TARGET ${test_name} PROPERTY CXX_STANDARD_REQUIRED ON)
+    set_property(TARGET ${test_name} PROPERTY CXX_EXTENSIONS OFF)
+endmacro()
+
+# Tests
+
+# Multiple stream open
+add_test(multiple_open_stream multiple_open_stream.cpp)

--- a/tests/multiple_open_stream.cpp
+++ b/tests/multiple_open_stream.cpp
@@ -1,0 +1,114 @@
+#include <XLink/XLink.h>
+#include <cstdio>
+#include <vector>
+#include <string>
+#include <chrono>
+#include <thread>
+#include <algorithm>
+#include <cstring>
+#include <atomic>
+
+// The following is an Server side (host) test that opens many streams in random order.
+// Mainly used to test stream desync issue.
+
+// Use the following code on Client side (device) to test
+// ...
+//    // loop through streams
+//    constexpr static auto NUM_STREAMS = 16;
+//    std::array<std::thread, NUM_STREAMS> threads;
+//    for(int i = 0; i < NUM_STREAMS; i++){
+//        threads[i] = std::thread([i](){
+//            std::string name = "test_";
+//            auto s = XLinkOpenStream(0, (name + std::to_string(i)).c_str(), 1024);
+//            assert(s != INVALID_STREAM_ID);
+//            auto w = XLinkWriteData(s, (uint8_t*) &s, sizeof(s));
+//            assert(w == X_LINK_SUCCESS);
+//        });
+//    }
+//    for(auto& thread : threads){
+//        thread.join();
+//    }
+// ...
+
+int main() {
+
+    XLinkGlobalHandler_t gHandler;
+    XLinkInitialize(&gHandler);
+
+    // Search for booted device
+    deviceDesc_t deviceDesc, inDeviceDesc;
+    inDeviceDesc.protocol = X_LINK_ANY_PROTOCOL;
+    if(X_LINK_SUCCESS != XLinkFindFirstSuitableDevice(X_LINK_BOOTED, inDeviceDesc, &deviceDesc)){
+        printf("Didn't find a device\n");
+        return -1;
+    }
+
+    printf("Device name: %s\n", deviceDesc.name);
+
+    XLinkHandler_t handler;
+    handler.devicePath = deviceDesc.name;
+    handler.protocol = deviceDesc.protocol;
+    XLinkConnect(&handler);
+
+    // loop randomly over streams
+    constexpr static auto NUM_STREAMS = 16;
+    std::vector<int> randomized;
+    for(int i = 0; i < NUM_STREAMS; i++){
+        randomized.push_back(i);
+    }
+    std::random_shuffle(std::begin(randomized), std::end(randomized));
+
+    std::thread threads[NUM_STREAMS];
+    streamId_t streams[NUM_STREAMS];
+    for(auto i : randomized){
+        threads[i] = std::thread([&, i](){
+            std::string name = "test_" + std::to_string(i);
+            auto s = XLinkOpenStream(handler.linkId, name.c_str(), 1024);
+            if(s == INVALID_STREAM_ID){
+                printf("Open stream failed...\n");
+            } else {
+                printf("Open stream OK - name %s, id: 0x%08X\n", name.c_str(), s);
+            }
+            streams[i] = s;
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    for(auto i : randomized){
+        threads[i].join();
+    }
+
+    // Optionally, print stream names and ids here
+    std::atomic<bool> success{true};
+    for(auto i : randomized){
+        threads[i] = std::thread([i, &streams, &success](){
+            std::string name = "test_" + std::to_string(i);
+            auto s = streams[i];
+
+            streamPacketDesc_t* p;
+            XLinkError_t err = XLinkReadData(s, &p);
+
+            if(err == X_LINK_SUCCESS && p && p->data && s == *((streamId_t*) p->data)) {
+                // OK
+            } else {
+                streamId_t id;
+                memcpy(&id, p->data, sizeof(id));
+                printf("DESYNC error - name %s, id: 0x%08X, response id: 0x%08X\n", name.c_str(), s, id);
+                success = false;
+            }
+
+        });
+    }
+    for(auto i : randomized){
+        threads[i].join();
+    }
+
+    XLinkResetRemote(handler.linkId);
+
+    if(success){
+        printf("Success!\n");
+        return 0;
+    } else {
+        printf("Error!\n");
+        return -1;
+    }
+}


### PR DESCRIPTION
Backwards compatible for for desynchronization of opening streams from both device and host side.

Closes #6

 - Added a test for future reference.
 - The fix itself is in `shared/src/XLinkDispatcherImpl.c`