### PR TITLE
Remote reset timeout function

### DIFF
--- a/include/XLink/XLink.h
+++ b/include/XLink/XLink.h
@@ -117,6 +117,15 @@ XLinkError_t XLinkBootFirmware(const deviceDesc_t* deviceDesc, const char* firmw
 XLinkError_t XLinkResetRemote(linkId_t id);
 
 /**
+ * @brief Resets the remote device and close all open local handles for this device
+ * @warning This function should be used in a host application
+ * @param[in] id - link Id obtained from XLinkConnect in the handler parameter
+ * @return Status code of the operation: X_LINK_SUCCESS (0) for success
+ */
+
+XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs);
+
+/**
  * @brief Closes all and release all memory
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -297,6 +297,59 @@ XLinkError_t XLinkResetRemote(linkId_t id)
     return X_LINK_SUCCESS;
 }
 
+XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs)
+{
+    xLinkDesc_t* link = getLinkById(id);
+    XLINK_RET_IF(link == NULL);
+
+    if (getXLinkState(link) != XLINK_UP) {
+        mvLog(MVLOG_WARN, "Link is down, close connection to device without reset");
+        XLinkPlatformCloseRemote(&link->deviceHandle);
+        return X_LINK_COMMUNICATION_NOT_OPEN;
+    }
+
+    // Add event to reset device. After sending it, dispatcher will close fd link
+    xLinkEvent_t event = {0};
+    event.header.type = XLINK_RESET_REQ;
+    event.deviceHandle = link->deviceHandle;
+    mvLog(MVLOG_DEBUG, "sending reset remote event\n");
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_REALTIME, &start);
+
+    struct timespec absTimeout = start;
+    int64_t sec = timeoutMs / 1000;
+    absTimeout.tv_sec += sec;
+    absTimeout.tv_nsec += (timeoutMs - sec) * 1000000;
+    int64_t secOver = absTimeout.tv_nsec / 1000000000;
+    absTimeout.tv_nsec -= secOver * 1000000000;
+    absTimeout.tv_sec += secOver;
+
+    xLinkEvent_t* ev = DispatcherAddEvent(EVENT_LOCAL, &event);
+    if(ev == NULL) {
+        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s\n",
+            TypeToStr(event.header.type), event.header.id, event.header.streamName);
+        return X_LINK_ERROR;
+    }
+
+    XLinkError_t ret = DispatcherWaitEventCompleteTimeout(&link->deviceHandle, absTimeout);
+
+    if(ret != X_LINK_SUCCESS){
+        // Close remote causes to close any links which unblocks the previous events
+        // It cleans the rest of dispatcher properly
+        XLinkPlatformCloseRemote(&link->deviceHandle);
+    }
+
+    // Wait for dispatcher to be closed
+    if(XLink_sem_wait(&link->dispatcherClosedSem)) {
+        mvLog(MVLOG_ERROR,"can't wait dispatcherClosedSem\n");
+        return X_LINK_ERROR;
+    }
+
+    return ret;
+
+}
+
 XLinkError_t XLinkResetAll()
 {
 #if defined(NO_BOOT)

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -23,6 +23,10 @@
 
 #define MAX_PATH_LENGTH (255)
 
+#if (defined(_WIN32) || defined(_WIN64))
+#include "win_time.h"
+#endif
+
 // ------------------------------------
 // Global fields. Begin.
 // ------------------------------------


### PR DESCRIPTION
Adds a timeout version of remote reset, to add in cases where read/writes gets blocked indefinitely (when device doesn't indicate connection failure properly - TCP case specific)