### PR TITLE
replace exit() calls -- they force terminate the main app in trivial situations

### DIFF
--- a/include/XLink/XLinkErrorUtils.h
+++ b/include/XLink/XLinkErrorUtils.h
@@ -10,7 +10,7 @@ extern "C"
 {
 #endif
 
-#ifdef NDEBUG  // Release configuration
+#if 1  // Release configuration
 
     #ifndef ASSERT_XLINK
     #define ASSERT_XLINK(condition) do { \

--- a/include/XLink/XLinkPlatformErrorUtils.h
+++ b/include/XLink/XLinkPlatformErrorUtils.h
@@ -10,7 +10,7 @@ extern "C"
 {
 #endif
 
-#ifdef NDEBUG  // Release configuration
+#if 1  // Release configuration
 
     #ifndef ASSERT_XLINK_PLATFORM_R
     #define ASSERT_XLINK_PLATFORM_R(condition, err) do { \

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -543,7 +543,14 @@ int usbPlatformConnect(const char *devPathRead, const char *devPathWrite, void *
 
     if (connect(usbFdWrite, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0)
     {
-        exit(1);
+        mvLog(MVLOG_ERROR, "connect(usbFdWrite,...) returned < 0\n");
+        if (usbFdRead >= 0)
+            close(usbFdRead);
+        if (usbFdWrite >= 0)
+            close(usbFdWrite);
+        usbFdRead = -1;
+        usbFdWrite = -1;
+        return X_LINK_PLATFORM_ERROR;
     }
     return 0;
 


### PR DESCRIPTION
XLink is calling exit() in some situations which force terminates the main app. Naturally, a library should not do this -- it should instead return error values or throw. As this is C code, it should return error values.

Related issue luxonis/depthai-core#257

### Needs discussion

1. I do not have a test harness to test the change in `PlatformDeviceControl.c`. It is dependent on `USE_USB_VSC` not defined....yet the cmake for the project seems to always define it in CMakefiles.txt line 56. So perhaps this is a non-issue.
2. Also in `PlatformDeviceControl.c` line 538 is likely errant code. Memset is using the character `0` aka value 48 and not the value zero. As I look at the struct...this doesn't look correct. It is not an exit() issue so I haven't included a code change...but...suspicious. Compare to line 650.

