### PR TITLE
Fixed regression ignoring SIGPIPE signal

### DIFF
--- a/src/pc/PlatformData.c
+++ b/src/pc/PlatformData.c
@@ -34,6 +34,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <libusb.h>
+#include <signal.h>
 #endif
 
 #ifdef USE_LINK_JTAG
@@ -401,17 +402,9 @@ static int tcpipPlatformWrite(void *fd, void *data, int size)
         //rc = write((intptr_t)fd, &((char*)data)[byteCount], size - byteCount);
 
         int flags = 0;
-
-        // Disable sigpipe reception on send
-        #if !defined(SIGPIPE)
-            // Pipe signal does not exist, there no sigpipe to ignore on send
-        #elif defined(SO_NOSIGPIPE)
-            // handled on socket creation
-        #elif defined(MSG_NOSIGNAL)
+        #if defined(MSG_NOSIGNAL)
             // Use flag NOSIGNAL on send call
             flags = MSG_NOSIGNAL;
-        #else
-            #error Can not disable SIGPIPE
         #endif
 
         TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -641,15 +641,9 @@ int tcpipPlatformConnect(const char *devPathRead, const char *devPathWrite, void
     }
 
     // Disable sigpipe reception on send
-    #if !defined(SIGPIPE)
-        // Pipe signal does not exist, there no sigpipe to ignore on send
-    #elif defined(SO_NOSIGPIPE)
+    #if defined(SO_NOSIGPIPE)
         const int set = 1;
         setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
-    #elif defined(MSG_NOSIGNAL)
-        // handled on write
-    #else
-        #error Can not disable SIGPIPE
     #endif
 
     struct sockaddr_in serv_addr = { 0 };


### PR DESCRIPTION
Because of a missing `signal.h` include, `SIGPIPE` wasn't defined, which ignored setting the `MSG_NOSIGNAL` on writes.

Removed actual `SIGPIPE` check and left only `MSG_NOSIGNAL` and `SO_NOSIGPIPE` which are defined in `sys/socket.h`

Checked against macOS and Linux