### PR TITLE
add move semantics for XLink packets

### DIFF
--- a/include/XLink/XLink.h
+++ b/include/XLink/XLink.h
@@ -246,10 +246,36 @@ XLinkError_t XLinkReadData(streamId_t streamId, streamPacketDesc_t** packet);
  * @brief Reads data from local stream. Will only have something if it was written to by the remote
  * @param[in]   streamId – stream link Id obtained from XLinkOpenStream call
  * @param[out]  packet – structure containing output data buffer and received size
- * @param[out]  msTimeout – time in milliseconds after which operation times out
+ * @param[in]   msTimeout – time in milliseconds after which operation times out
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success, X_LINK_TIMEOUT when msTimeout time passes
  */
 XLinkError_t XLinkReadDataWithTimeout(streamId_t streamId, streamPacketDesc_t** packet, unsigned int msTimeout);
+
+/**
+ * @brief Reads data from local stream and moves ownership. Will only have something if it was written to by the remote
+ * @note Caller is responsible for deallocating with XLinkDeallocateMoveData(streamPacketDesc_t::data, streamPacketDesc_t::length)
+ * @param[in]   streamId - stream link Id obtained from XLinkOpenStream call
+ * @param[out]  packet - structure containing output data buffer and received size
+ * @return Status code of the operation: X_LINK_SUCCESS (0) for success
+ */
+XLinkError_t XLinkReadMoveData(streamId_t streamId, streamPacketDesc_t* const packet);
+
+/**
+ * @brief Reads data from local stream and moves ownership. Will only have something if it was written to by the remote
+ * @note Caller is responsible for deallocating with XLinkDeallocateMoveData(streamPacketDesc_t::data, streamPacketDesc_t::length)
+ * @param[in]   streamId - stream link Id obtained from XLinkOpenStream call
+ * @param[out]  packet - structure containing output data buffer and received size
+ * @param[in]   msTimeout – time in milliseconds after which operation times out
+ * @return Status code of the operation: X_LINK_SUCCESS (0) for success, X_LINK_TIMEOUT when msTimeout time passes
+ */
+XLinkError_t XLinkReadMoveDataWithTimeout(streamId_t streamId, streamPacketDesc_t *const packet, const unsigned int msTimeout);
+
+/**
+ * @brief Deallocate memory within streamPacketDesc_t received from a previous call to XLinkReadMoveData() or XLinkReadMoveDataWithTimeout()
+ * @param[in]  data - streamPacketDesc_t::data pointer
+ * @param[in]  length - streamPacketDesc_t::length
+ */
+void XLinkDeallocateMoveData(void* const data, const uint32_t length);
 
 /**
  * @brief Releases data from stream - This should be called after the data obtained from

--- a/include/XLink/XLinkMacros.h
+++ b/include/XLink/XLinkMacros.h
@@ -6,17 +6,14 @@
 #define MVMACROS_H__
 
 #define CIRCULAR_INCREMENT(x, maxVal) \
-    { \
-         x++; \
-         if (x == maxVal) \
-             x = 0; \
+    {                                 \
+        x = (++x) % maxVal;           \
     }
 
 #define CIRCULAR_INCREMENT_BASE(x, maxVal, base) \
-    { \
-        x++; \
-        if (x == maxVal) \
-            x = base; \
+    {                                            \
+        if (++x == maxVal)                       \
+            x = base;                            \
     }
 
 

--- a/include/XLink/XLinkPrivateDefines.h
+++ b/include/XLink/XLinkPrivateDefines.h
@@ -61,7 +61,7 @@ typedef struct xLinkDesc_t {
     XLink_sem_t dispatcherClosedSem;
     UsbSpeed_t usbConnSpeed;
     char mxSerialId[XLINK_MAX_MX_ID_SIZE];
-    
+
     //Deprecated fields. Begin.
     int hostClosedFD;
     //Deprecated fields. End.
@@ -138,6 +138,7 @@ typedef struct xLinkEventHeader_t{
             uint32_t bufferFull : 1;
             uint32_t sizeTooBig : 1;
             uint32_t noSuchStream : 1;
+            uint32_t moveSemantic : 1;
         }bitField;
     }flags;
 }xLinkEventHeader_t;

--- a/src/shared/XLinkDispatcher.c
+++ b/src/shared/XLinkDispatcher.c
@@ -349,7 +349,9 @@ xLinkEvent_t* DispatcherAddEvent(xLinkEventOrigin_t origin, xLinkEvent_t *event)
 
             return NULL;
         }
+        const uint32_t tmpMoveSem = event->header.flags.bitField.moveSemantic;
         event->header.flags.raw = 0;
+        event->header.flags.bitField.moveSemantic = tmpMoveSem;
         ev = addNextQueueElemToProc(curr, &curr->lQueue, event, sem, origin);
     } else {
         ev = addNextQueueElemToProc(curr, &curr->rQueue, event, NULL, origin);

--- a/src/shared/XLinkDispatcherImpl.c
+++ b/src/shared/XLinkDispatcherImpl.c
@@ -24,6 +24,8 @@
 
 static int isStreamSpaceEnoughFor(streamDesc_t* stream, uint32_t size);
 
+// moves packet and its data out of XLink; caller is responsible for freeing data resource
+static streamPacketDesc_t* movePacketFromStream(streamDesc_t *stream);
 static streamPacketDesc_t* getPacketFromStream(streamDesc_t* stream);
 static int releasePacketFromStream(streamDesc_t* stream, uint32_t* releasedSize);
 static int addNewPacketToStream(streamDesc_t* stream, void* buffer, uint32_t size);
@@ -95,7 +97,7 @@ int dispatcherEventReceive(xLinkEvent_t* event){
     return handleIncomingEvent(event);
 }
 
-//this function should be called only for remote requests
+//this function should be called only for local requests
 int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
 {
     streamDesc_t* stream;
@@ -148,7 +150,15 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
                 XLINK_SET_EVENT_FAILED_AND_SERVE(event);
                 break;
             }
-            streamPacketDesc_t* packet = getPacketFromStream(stream);
+
+            streamPacketDesc_t* packet;
+            if (event->header.flags.bitField.moveSemantic) {
+                packet = movePacketFromStream(stream);
+            }
+            else {
+                packet = getPacketFromStream(stream);
+            }
+
             if (packet){
                 //the read can be served with this packet
                 event->data = packet;
@@ -445,6 +455,15 @@ void dispatcherCloseLink(void* fd, int fullClose)
         return;
     }
 
+    // TODO investigate race condition that is (probably) later caught
+    // due to changing the global `xLinkDesc_t availableXLinks[MAX_LINKS]`
+    // without any thread protection. The dispatcher thread can be calling this function
+    // while an app thread calls `XLinkReadData()` which calls `getLinkByStreamId()` which calls
+    // both `getLinkById()` and `getXLinkState()`. The latter two read the global `availableXLinks`
+    // and depending on the two threads execution timing could result in the xlink being invalidated
+    // after the app's thread did the "is xlink valid" test. This leads to the app's thread
+    // creating an `xLinkEvent_t` with outdated xlink info. When that event gets to the
+    // event processing loop, the validity of the xlink state will be checked again and be handled
     if (!fullClose) {
         link->peerState = XLINK_DOWN;
         return;
@@ -461,10 +480,15 @@ void dispatcherCloseLink(void* fd, int fullClose)
             continue;
         }
 
+        // TODO integrate pending changes
+        // * use move semantic, this prevents the memset(0) from causing leak/crash
+        // * make new xlink-specific semaphore and wait on it during xlink lookup, create, etc.
+        XLink_sem_wait(&stream->sem);
         while (getPacketFromStream(stream) || stream->blockedPackets) {
             releasePacketFromStream(stream, NULL);
         }
-
+        stream->id = INVALID_STREAM_ID;
+        XLink_sem_post(&stream->sem);
         XLinkStreamReset(stream);
     }
 
@@ -506,6 +530,32 @@ streamPacketDesc_t* getPacketFromStream(streamDesc_t* stream)
     if (stream->availablePackets)
     {
         ret = &stream->packets[stream->firstPacketUnused];
+        stream->availablePackets--;
+        CIRCULAR_INCREMENT(stream->firstPacketUnused,
+                           XLINK_MAX_PACKETS_PER_STREAM);
+        stream->blockedPackets++;
+    }
+    return ret;
+}
+
+// TODO add multithread access to the same stream; not currently supported
+// due to issues like the order of get/move and release of packets
+streamPacketDesc_t* movePacketFromStream(streamDesc_t* stream)
+{
+    streamPacketDesc_t *ret = NULL;
+    if (stream->availablePackets)
+    {
+        ret = malloc(sizeof(streamPacketDesc_t));
+        ret->data = NULL;
+        ret->length = 0;
+
+        // copy fields of first unused packet
+        *ret = stream->packets[stream->firstPacketUnused];
+
+        // mark packet to no longer own data; keep length for later ack's
+        stream->packets[stream->firstPacketUnused].data = NULL;
+
+        // update circular buffer indices
         stream->availablePackets--;
         CIRCULAR_INCREMENT(stream->firstPacketUnused,
                            XLINK_MAX_PACKETS_PER_STREAM);

--- a/src/shared/XLinkPrivateFields.c
+++ b/src/shared/XLinkPrivateFields.c
@@ -65,6 +65,7 @@ streamId_t getStreamIdByName(xLinkDesc_t* link, const char* name)
 
 streamDesc_t* getStreamById(void* fd, streamId_t id)
 {
+    XLINK_RET_ERR_IF(id == INVALID_STREAM_ID, NULL);
     xLinkDesc_t* link = getLink(fd);
     XLINK_RET_ERR_IF(link == NULL, NULL);
     int stream;

--- a/src/shared/XLinkStream.c
+++ b/src/shared/XLinkStream.c
@@ -43,6 +43,8 @@ void XLinkStreamReset(streamDesc_t* stream) {
         mvLog(MVLOG_DEBUG, "Cannot destroy semaphore\n");
     }
 
+    // sets all stream fields, including the packets circular buffer to NULL
+    // with no check to see if something is open, packet is "blocked", etc.
     memset(stream, 0, sizeof(*stream));
     stream->id = INVALID_STREAM_ID;
 }


### PR DESCRIPTION
This is the xlink portion of work to fix https://github.com/luxonis/depthai-core/issues/257
I request review of this PR for approach, style, and validity. 🔍👍

* enables move semantic for ownership of packet data/memory using C.
* adds public xlink APIs for move, move w/ timeout, and deallocating
* ready to be used by my pending PR to depthai-core to use these move semantics

I have added comments/notes highlighting bugs with `BUGBUG` and suggested future work `TODO`.
I fully intend to forcepush an update as we discuss and resolve concerns.

### Approach

My first approach was to create a new `xLinkEventType_t::XLINK_READ_MOVE_REQ`. This required far too much change/coordination for handshakes, coordination of local/remote fill levels, etc. I discarded this work. 😝

My second approach (this PR) is to use all of the existing code and events. Then to simply add `xLinkEventHeader_t::flags::bitField::moveSemantic` and a few isolated functions to move memory pointers (transferring ownership) instead of copying pointers (unclear ownership). The bitflag is named so it can be anywhere in the field allowing for later upstream merges to be added easily.