### PR TITLE
XLinkConnect thread safety

### DIFF
--- a/include/XLink/XLinkPrivateFields.h
+++ b/include/XLink/XLinkPrivateFields.h
@@ -25,6 +25,7 @@ extern XLinkGlobalHandler_t* glHandler; //TODO need to either protect this with 
                                         //or make profiling data per device
 
 extern xLinkDesc_t availableXLinks[MAX_LINKS];
+extern pthread_mutex_t availableXLinksMutex;
 extern DispatcherControlFunctions controlFunctionTbl;
 extern sem_t  pingSem; //to b used by myriad
 

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -35,6 +35,7 @@ XLinkGlobalHandler_t* glHandler; //TODO need to either protect this with semapho
                                  //or make profiling data per device
 
 xLinkDesc_t availableXLinks[MAX_LINKS];
+pthread_mutex_t availableXLinksMutex = PTHREAD_MUTEX_INITIALIZER;
 sem_t  pingSem; //to b used by myriad
 DispatcherControlFunctions controlFunctionTbl;
 linkId_t nextUniqueLinkId = 0; //incremental number, doesn't get decremented.
@@ -51,6 +52,7 @@ linkId_t nextUniqueLinkId = 0; //incremental number, doesn't get decremented.
 
 static linkId_t getNextAvailableLinkUniqueId();
 static xLinkDesc_t* getNextAvailableLink();
+static void freeGivenLink(xLinkDesc_t* link);
 
 #ifdef __PC__
 
@@ -125,8 +127,6 @@ XLinkError_t XLinkInitialize(XLinkGlobalHandler_t* globalHandler)
     link = getNextAvailableLink();
     if (link == NULL)
         return X_LINK_COMMUNICATION_NOT_OPEN;
-
-    link->id = getNextAvailableLinkUniqueId();
     link->peerState = XLINK_UP;
     link->deviceHandle.xLinkFD = NULL;
     link->deviceHandle.protocol = globalHandler->protocol;
@@ -197,6 +197,11 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
          * Connection may be unsuccessful at some amount of first tries.
          * In this case, asserting the status provides enormous amount of logs in tests.
          */
+
+        // Free used link
+        freeGivenLink(link);
+
+        // Return an informative error
         return X_LINK_COMMUNICATION_NOT_OPEN;
     }
 
@@ -214,7 +219,6 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
         return X_LINK_TIMEOUT;
     }
 
-    link->id = getNextAvailableLinkUniqueId();
     link->peerState = XLINK_UP;
     #if (!defined(_WIN32) && !defined(_WIN64) )
         link->usbConnSpeed = get_usb_speed();
@@ -452,6 +456,7 @@ const char* XLinkGetMxSerial(linkId_t id){
 // Helpers implementation. Begin.
 // ------------------------------------
 
+// Used only by getNextAvailableLink
 static linkId_t getNextAvailableLinkUniqueId()
 {
     linkId_t start = nextUniqueLinkId;
@@ -479,6 +484,15 @@ static linkId_t getNextAvailableLinkUniqueId()
 }
 
 static xLinkDesc_t* getNextAvailableLink() {
+
+    XLINK_RET_ERR_IF(pthread_mutex_lock(&availableXLinksMutex) != 0, NULL);
+
+    linkId_t id = getNextAvailableLinkUniqueId();
+    if(id == INVALID_LINK_ID){
+        XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
+        return NULL;
+    }
+
     int i;
     for (i = 0; i < MAX_LINKS; i++) {
         if (availableXLinks[i].id == INVALID_LINK_ID) {
@@ -488,17 +502,38 @@ static xLinkDesc_t* getNextAvailableLink() {
 
     if(i >= MAX_LINKS) {
         mvLog(MVLOG_ERROR,"%s():- no next available link!\n", __func__);
+        XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
         return NULL;
     }
 
     xLinkDesc_t* link = &availableXLinks[i];
+    link->id = id;
 
     if (XLink_sem_init(&link->dispatcherClosedSem, 0 ,0)) {
         mvLog(MVLOG_ERROR, "Cannot initialize semaphore\n");
+        XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
         return NULL;
     }
 
+    XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
+
     return link;
+}
+
+static void freeGivenLink(xLinkDesc_t* link) {
+
+    if(pthread_mutex_lock(&availableXLinksMutex) != 0){
+        mvLog(MVLOG_ERROR, "Cannot lock mutex\n");
+        return;
+    }
+
+    link->id = INVALID_LINK_ID;
+    if (XLink_sem_destroy(&link->dispatcherClosedSem)) {
+        mvLog(MVLOG_ERROR, "Cannot destroy semaphore\n");
+    }
+
+    pthread_mutex_unlock(&availableXLinksMutex);
+
 }
 
 #ifdef __PC__

--- a/src/shared/XLinkPrivateFields.c
+++ b/src/shared/XLinkPrivateFields.c
@@ -19,19 +19,34 @@
 
 xLinkDesc_t* getLinkById(linkId_t id)
 {
+    XLINK_RET_ERR_IF(pthread_mutex_lock(&availableXLinksMutex) != 0, NULL);
+
     int i;
-    for (i = 0; i < MAX_LINKS; i++)
-        if (availableXLinks[i].id == id)
+    for (i = 0; i < MAX_LINKS; i++) {
+        if (availableXLinks[i].id == id) {
+            XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
             return &availableXLinks[i];
+        }
+    }
+
+    XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
     return NULL;
 }
 
 xLinkDesc_t* getLink(void* fd)
 {
+
+    XLINK_RET_ERR_IF(pthread_mutex_lock(&availableXLinksMutex) != 0, NULL);
+
     int i;
-    for (i = 0; i < MAX_LINKS; i++)
-        if (availableXLinks[i].deviceHandle.xLinkFD == fd)
+    for (i = 0; i < MAX_LINKS; i++) {
+        if (availableXLinks[i].deviceHandle.xLinkFD == fd) {
+            XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
             return &availableXLinks[i];
+        }
+    }
+
+    XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
     return NULL;
 }
 


### PR DESCRIPTION
Scenario this attempts to resolve is the following:
Two threads try to connect to separate devices at the same time. In XLinkConnect:
 - T1, calls `getNextAvailableLink` and retrieves a pointer to a xLinkDesc_t entry (eg first entry). Entry isn't yet marked as used and is returned as is.
 - T2, calls `getNextAvailableLink` and retrieves same pointer (eg first entry), because T1 didn't yet assign a valid ID to the link (happens later in `XLinkConnect`)

After this both threads modify the same entry.

This PR combines retrieving the next available link with assigning a valid ID to it. If it later shows that link isn't needed, it can be "freed" by setting it an invalid ID again and destroying the previously created semaphore. 