### PR TITLE
Resolves a possible race to streamDesc_t entry

### DIFF
--- a/include/XLink/XLinkDispatcher.h
+++ b/include/XLink/XLinkDispatcher.h
@@ -31,7 +31,7 @@ typedef struct {
 XLinkError_t DispatcherInitialize(DispatcherControlFunctions *controlFunc);
 XLinkError_t DispatcherStart(xLinkDeviceHandle_t *deviceHandle);
 int DispatcherClean(xLinkDeviceHandle_t *deviceHandle);
-int DispatcherReset(xLinkDeviceHandle_t *deviceHandle);
+int DispatcherDeviceFdDown(xLinkDeviceHandle_t *deviceHandle);
 
 xLinkEvent_t* DispatcherAddEvent(xLinkEventOrigin_t origin, xLinkEvent_t *event);
 int DispatcherWaitEventComplete(xLinkDeviceHandle_t *deviceHandle);

--- a/include/XLink/XLinkStream.h
+++ b/include/XLink/XLinkStream.h
@@ -37,6 +37,4 @@ typedef struct{
 XLinkError_t XLinkStreamInitialize(
     streamDesc_t* stream, streamId_t id, const char* name);
 
-void XLinkStreamReset(streamDesc_t* stream);
-
 #endif //_XLINKSTREAM_H

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -343,9 +343,9 @@ XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs)
     XLinkError_t ret = DispatcherWaitEventCompleteTimeout(&link->deviceHandle, absTimeout);
 
     if(ret != X_LINK_SUCCESS){
-        // Close remote causes to close any links which unblocks the previous events
-        // It cleans the rest of dispatcher properly
-        DispatcherReset(&link->deviceHandle);
+        // Closing device link unblocks any blocked events
+        // Afterwards the dispatcher can properly cleanup in its own thread
+        DispatcherDeviceFdDown(&link->deviceHandle);
     }
 
     // Wait for dispatcher to be closed

--- a/src/shared/XLinkDispatcher.c
+++ b/src/shared/XLinkDispatcher.c
@@ -959,7 +959,7 @@ static int dispatcherClean(xLinkSchedulerState_t* curr)
 }
 
 static int dispatcherDeviceFdDown(xLinkSchedulerState_t* curr){
-
+    ASSERT_XLINK(curr != NULL);
     XLINK_RET_ERR_IF(pthread_mutex_lock(&reset_mutex), 1);
     int ret = 0;
 
@@ -974,7 +974,7 @@ static int dispatcherDeviceFdDown(xLinkSchedulerState_t* curr){
     }
 
     if(pthread_mutex_unlock(&reset_mutex) != 0) {
-        mvLog(MVLOG_ERROR, "Failed to unlock clean_mutex");
+        mvLog(MVLOG_ERROR, "Failed to unlock reset_mutex");
         ret = 1;
     }
 
@@ -1018,6 +1018,7 @@ static int dispatcherReset(xLinkSchedulerState_t* curr)
 
     if(pthread_mutex_unlock(&reset_mutex) != 0) {
         mvLog(MVLOG_ERROR, "Failed to unlock clean_mutex after clearing dispatcher");
+        return 1;
     }
 
     return 0;

--- a/src/shared/XLinkDispatcherImpl.c
+++ b/src/shared/XLinkDispatcherImpl.c
@@ -487,9 +487,12 @@ void dispatcherCloseLink(void* fd, int fullClose)
         while (getPacketFromStream(stream) || stream->blockedPackets) {
             releasePacketFromStream(stream, NULL);
         }
+        memset(stream, 0, sizeof(*stream));
         stream->id = INVALID_STREAM_ID;
         XLink_sem_post(&stream->sem);
-        XLinkStreamReset(stream);
+        if(XLink_sem_destroy(&stream->sem)) {
+            mvLog(MVLOG_DEBUG, "Cannot destroy semaphore\n");
+        }
     }
 
     if(XLink_sem_destroy(&link->dispatcherClosedSem)) {

--- a/src/shared/XLinkDispatcherImpl.c
+++ b/src/shared/XLinkDispatcherImpl.c
@@ -476,20 +476,24 @@ void dispatcherCloseLink(void* fd, int fullClose)
 
     for (int index = 0; index < XLINK_MAX_STREAMS; index++) {
         streamDesc_t* stream = &link->availableStreams[index];
-        if (!stream) {
+        // Wasn't initialized
+        if(stream->id == INVALID_STREAM_ID) {
             continue;
         }
 
         // TODO integrate pending changes
         // * use move semantic, this prevents the memset(0) from causing leak/crash
         // * make new xlink-specific semaphore and wait on it during xlink lookup, create, etc.
+
         XLink_sem_wait(&stream->sem);
         while (getPacketFromStream(stream) || stream->blockedPackets) {
             releasePacketFromStream(stream, NULL);
         }
+        // XLink reset stream
         memset(stream, 0, sizeof(*stream));
         stream->id = INVALID_STREAM_ID;
         XLink_sem_post(&stream->sem);
+        // Finish up cleaning the stream
         if(XLink_sem_destroy(&stream->sem)) {
             mvLog(MVLOG_DEBUG, "Cannot destroy semaphore\n");
         }

--- a/src/shared/XLinkPrivateFields.c
+++ b/src/shared/XLinkPrivateFields.c
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include "stdlib.h"
@@ -66,16 +65,14 @@ streamId_t getStreamIdByName(xLinkDesc_t* link, const char* name)
 
 streamDesc_t* getStreamById(void* fd, streamId_t id)
 {
+    XLINK_RET_ERR_IF(id == INVALID_STREAM_ID, NULL);
     xLinkDesc_t* link = getLink(fd);
     XLINK_RET_ERR_IF(link == NULL, NULL);
     int stream;
     for (stream = 0; stream < XLINK_MAX_STREAMS; stream++) {
         if (link->availableStreams[stream].id == id) {
 
-            int rc;
-            while(((rc = XLink_sem_wait(&link->availableStreams[stream].sem)) == -1) && errno == EINTR)
-                continue;
-            if(rc || link->availableStreams[stream].id == INVALID_STREAM_ID) {
+            if(XLink_sem_wait(&link->availableStreams[stream].sem)){
                 return NULL;
             }
 
@@ -93,10 +90,7 @@ streamDesc_t* getStreamByName(xLinkDesc_t* link, const char* name)
         if (link->availableStreams[stream].id != INVALID_STREAM_ID &&
             strcmp(link->availableStreams[stream].name, name) == 0) {
 
-            int rc;
-            while(((rc = XLink_sem_wait(&link->availableStreams[stream].sem)) == -1) && errno == EINTR)
-                continue;
-            if(rc || link->availableStreams[stream].id == INVALID_STREAM_ID) {
+            if(XLink_sem_wait(&link->availableStreams[stream].sem)){
                 return NULL;
             }
 

--- a/src/shared/XLinkPrivateFields.c
+++ b/src/shared/XLinkPrivateFields.c
@@ -72,7 +72,9 @@ streamDesc_t* getStreamById(void* fd, streamId_t id)
     for (stream = 0; stream < XLINK_MAX_STREAMS; stream++) {
         if (link->availableStreams[stream].id == id) {
             XLink_sem_wait(&link->availableStreams[stream].sem);
-
+            if(link->availableStreams[stream].id == INVALID_STREAM_ID){
+                return NULL;
+            }
             return &link->availableStreams[stream];
         }
     }
@@ -87,7 +89,9 @@ streamDesc_t* getStreamByName(xLinkDesc_t* link, const char* name)
         if (link->availableStreams[stream].id != INVALID_STREAM_ID &&
             strcmp(link->availableStreams[stream].name, name) == 0) {
             XLink_sem_wait(&link->availableStreams[stream].sem);
-
+            if(link->availableStreams[stream].id == INVALID_STREAM_ID){
+                return NULL;
+            }
             return &link->availableStreams[stream];
         }
     }

--- a/src/shared/XLinkStream.c
+++ b/src/shared/XLinkStream.c
@@ -33,18 +33,3 @@ XLinkError_t XLinkStreamInitialize(
 
     return X_LINK_SUCCESS;
 }
-
-void XLinkStreamReset(streamDesc_t* stream) {
-    if(stream == NULL) {
-        return;
-    }
-
-    if(XLink_sem_destroy(&stream->sem)) {
-        mvLog(MVLOG_DEBUG, "Cannot destroy semaphore\n");
-    }
-
-    // sets all stream fields, including the packets circular buffer to NULL
-    // with no check to see if something is open, packet is "blocked", etc.
-    memset(stream, 0, sizeof(*stream));
-    stream->id = INVALID_STREAM_ID;
-}


### PR DESCRIPTION
An attempt/comment on some discussion from #29 

After semaphore is posted, the memset to 0 could occur (but not yet the `stream.id = INVALID_STREAM_ID`), which the blocked thread waiting at eg `getStreamById` wouldn't notice and continue returning the actual streamDesc_t*, which is actually already "closed"

This changes try to address that by setting the stream id to `INVALID_STREAM_ID` before posting the semaphore and not changing it afterwards. Also the blocked thread in `getStreamById` rechecks the actual ID afterwards to see if it was closed in the mean time it was waiting for the semaphore.

CC: @diablodale 