### PR TITLE
fix warning: multiple unsequenced modifications in circ buf macros

### DIFF
--- a/include/XLink/XLinkMacros.h
+++ b/include/XLink/XLinkMacros.h
@@ -7,7 +7,7 @@
 
 #define CIRCULAR_INCREMENT(x, maxVal) \
     {                                 \
-        x = (++x) % maxVal;           \
+        x = (x + 1) % maxVal;         \
     }
 
 #define CIRCULAR_INCREMENT_BASE(x, maxVal, base) \


### PR DESCRIPTION
Fix `warning: multiple unsequenced modifications to...` circular buffer macros.

I could not repro this warning on Win vs2019, U20.04, U21.10, clang, gcc, debug ,release, static, or dynamic builds.
Reading the C-spec, I could imagine how a compile might be unclear on the sequence. So I've updated the first macro with hope @szabi-luxonis will no longer have the warning when they compile it on their test harness.

Continues to compile clean and run well on my test machines and all test+examples pass.

As discussed with @szabi-luxonis  https://github.com/luxonis/XLink/pull/29/files/5d2d5023aff5caed817a47fae36e761347af8018#r789119871