### PR TITLE
TCP/IP protocol bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,18 @@ if (ENABLE_MYRIAD_NO_BOOT)
         NO_BOOT)
 endif()
 
+# Set C99 standard
 set_property(TARGET ${TARGET_NAME} PROPERTY C_STANDARD 99)
+# Set compiler features (c++11), and disables extensions (g++11)
+set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET ${TARGET_NAME} PROPERTY CXX_EXTENSIONS OFF)
+# Add interface transitive property (C++11)
+if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    target_compile_features(${TARGET_NAME} INTERFACE cxx_range_for)
+else()
+    target_compile_features(${TARGET_NAME} INTERFACE cxx_std_11)
+endif()
 
 # Examples
 if(XLINK_BUILD_EXAMPLES)

--- a/cmake/XLink.cmake
+++ b/cmake/XLink.cmake
@@ -5,10 +5,11 @@ set(XLINK_INCLUDE ${XLINK_ROOT_DIR}/include)
 set(XLINK_PRIVATE_INCLUDE ${XLINK_ROOT_DIR}/src/pc/protocols)
 
 file(GLOB PC_SRC             "${XLINK_ROOT_DIR}/src/pc/*.c")
+file(GLOB PC_SRC_CPP         "${XLINK_ROOT_DIR}/src/pc/*.cpp")
 file(GLOB PC_PROTO_SRC       "${XLINK_ROOT_DIR}/src/pc/protocols/*.c")
 file(GLOB_RECURSE SHARED_SRC "${XLINK_ROOT_DIR}/src/shared/*.c")
 
-list(APPEND XLINK_SOURCES ${PC_SRC} ${PC_PROTO_SRC} ${SHARED_SRC})
+list(APPEND XLINK_SOURCES ${PC_SRC} ${PC_SRC_CPP} ${PC_PROTO_SRC} ${SHARED_SRC})
 
 if(WIN32)
     set(XLINK_PLATFORM_INCLUDE ${XLINK_ROOT_DIR}/src/pc/Win/include)

--- a/src/pc/PlatformData.c
+++ b/src/pc/PlatformData.c
@@ -14,6 +14,7 @@
 #include "usb_boot.h"
 #include "pcie_host.h"
 #include "tcpip_host.h"
+#include "PlatformDeviceFd.h"
 
 #define MVLOG_UNIT_NAME PlatformData
 #include "XLinkLog.h"
@@ -366,19 +367,22 @@ int pciePlatformRead(void *f, void *data, int size)
 #endif
 }
 
-static int tcpipPlatformRead(void *fd, void *data, int size)
+static int tcpipPlatformRead(void *fdKey, void *data, int size)
 {
 #if defined(USE_TCP_IP)
     int nread = 0;
     int rc = -1;
 
+    void* tmpsockfd = NULL;
+    if(getPlatformDeviceFdFromKey(fdKey, &tmpsockfd)){
+        mvLog(MVLOG_FATAL, "Cannot find file descriptor by key");
+        return -1;
+    }
+    TCPIP_SOCKET sock = (TCPIP_SOCKET) tmpsockfd;
+
     while(nread < size)
     {
-        // TMP TMP - leaky test
-        TCPIP_SOCKET sock = *((TCPIP_SOCKET*)fd);
-        // TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
-
-        rc = recv((TCPIP_SOCKET)sock, &((char*)data)[nread], size - nread, 0);
+        rc = recv(sock, &((char*)data)[nread], size - nread, 0);
         if(rc <= 0)
         {
             return -1;
@@ -393,11 +397,18 @@ static int tcpipPlatformRead(void *fd, void *data, int size)
     return 0;
 }
 
-static int tcpipPlatformWrite(void *fd, void *data, int size)
+static int tcpipPlatformWrite(void *fdKey, void *data, int size)
 {
 #if defined(USE_TCP_IP)
     int byteCount = 0;
     int rc = -1;
+
+    void* tmpsockfd = NULL;
+    if(getPlatformDeviceFdFromKey(fdKey, &tmpsockfd)){
+        mvLog(MVLOG_FATAL, "Cannot find file descriptor by key");
+        return -1;
+    }
+    TCPIP_SOCKET sock = (TCPIP_SOCKET) tmpsockfd;
 
     while(byteCount < size)
     {
@@ -409,10 +420,6 @@ static int tcpipPlatformWrite(void *fd, void *data, int size)
             // Use flag NOSIGNAL on send call
             flags = MSG_NOSIGNAL;
         #endif
-
-        // TMP TMP - leaky test
-        TCPIP_SOCKET sock = *((TCPIP_SOCKET*)fd);
-        // TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
 
         rc = send(sock, &((char*)data)[byteCount], size - byteCount, flags);
         if(rc <= 0)

--- a/src/pc/PlatformData.c
+++ b/src/pc/PlatformData.c
@@ -374,8 +374,11 @@ static int tcpipPlatformRead(void *fd, void *data, int size)
 
     while(nread < size)
     {
-        TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
-        rc = recv((TCPIP_SOCKET)fd, &((char*)data)[nread], size - nread, 0);
+        // TMP TMP - leaky test
+        TCPIP_SOCKET sock = *((TCPIP_SOCKET*)fd);
+        // TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
+
+        rc = recv((TCPIP_SOCKET)sock, &((char*)data)[nread], size - nread, 0);
         if(rc <= 0)
         {
             return -1;
@@ -407,7 +410,10 @@ static int tcpipPlatformWrite(void *fd, void *data, int size)
             flags = MSG_NOSIGNAL;
         #endif
 
-        TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
+        // TMP TMP - leaky test
+        TCPIP_SOCKET sock = *((TCPIP_SOCKET*)fd);
+        // TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
+
         rc = send(sock, &((char*)data)[byteCount], size - byteCount, flags);
         if(rc <= 0)
         {

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -694,7 +694,10 @@ int tcpipPlatformConnect(const char *devPathRead, const char *devPathWrite, void
         return -1;
     }
 
-    *((TCPIP_SOCKET*)fd) = sock;
+    // TMP TMP - leaky "key" for FD
+    *fd = malloc(sizeof(TCPIP_SOCKET));
+    *((TCPIP_SOCKET*)*fd) = sock;
+
 #endif
     return 0;
 }
@@ -778,7 +781,9 @@ int tcpipPlatformClose(void *fd)
     return status;
 #else
 
-    intptr_t sockfd = (intptr_t)fd;
+    // intptr_t sockfd = (intptr_t)fd;
+    // TMP TMP - leaky malloc test
+    TCPIP_SOCKET sockfd = *((TCPIP_SOCKET*)fd);
     if(sockfd != -1)
     {
         status = shutdown(sockfd, SHUT_RDWR);

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -11,6 +11,7 @@
 #include "pcie_host.h"
 #include "tcpip_host.h"
 #include "XLinkStringUtils.h"
+#include "PlatformDeviceFd.h"
 
 #define MVLOG_UNIT_NAME PlatformDeviceControl
 #include "XLinkLog.h"
@@ -694,9 +695,9 @@ int tcpipPlatformConnect(const char *devPathRead, const char *devPathWrite, void
         return -1;
     }
 
-    // TMP TMP - leaky "key" for FD
-    *fd = malloc(sizeof(TCPIP_SOCKET));
-    *((TCPIP_SOCKET*)*fd) = sock;
+    // Store the socket and create a "unique" key instead
+    // (as file descriptors are reused and can cause a clash with lookups between scheduler and link)
+    *fd = createPlatformDeviceFdKey((void*) sock);
 
 #endif
     return 0;
@@ -768,30 +769,36 @@ int pciePlatformClose(void *f)
     return rc;
 }
 
-int tcpipPlatformClose(void *fd)
+int tcpipPlatformClose(void *fdKey)
 {
 #if defined(USE_TCP_IP)
 
     int status = 0;
 
+    void* tmpsockfd = NULL;
+    if(getPlatformDeviceFdFromKey(fdKey, &tmpsockfd)){
+        mvLog(MVLOG_FATAL, "Cannot find file descriptor by key");
+        return -1;
+    }
+    TCPIP_SOCKET sock = (TCPIP_SOCKET) tmpsockfd;
+
 #ifdef _WIN32
-    TCPIP_SOCKET sock = (TCPIP_SOCKET) fd;
     status = shutdown(sock, SD_BOTH);
     if (status == 0) { status = closesocket(sock); }
-    return status;
 #else
-
-    // intptr_t sockfd = (intptr_t)fd;
-    // TMP TMP - leaky malloc test
-    TCPIP_SOCKET sockfd = *((TCPIP_SOCKET*)fd);
-    if(sockfd != -1)
+    if(sock != -1)
     {
-        status = shutdown(sockfd, SHUT_RDWR);
-        if (status == 0) { status = close(sockfd); }
+        status = shutdown(sock, SHUT_RDWR);
+        if (status == 0) { status = close(sock); }
     }
-    return status;
-
 #endif
+
+    if(destroyPlatformDeviceFdKey(fdKey)){
+        mvLog(MVLOG_FATAL, "Cannot destory file descriptor key");
+        return -1;
+    }
+
+    return status;
 
 #endif
     return -1;

--- a/src/pc/PlatformDeviceFd.cpp
+++ b/src/pc/PlatformDeviceFd.cpp
@@ -1,0 +1,44 @@
+#include "PlatformDeviceFd.h"
+
+#include <unordered_map>
+#include <atomic>
+#include <mutex>
+#include <cstdint>
+
+static std::mutex mutex;
+static std::unordered_map<std::uintptr_t, void*> map;
+static std::uintptr_t uniqueFdKey{0x55};
+
+int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd){
+    if(fd == nullptr) return -1;
+    std::unique_lock<std::mutex> lock(mutex);
+
+    std::uintptr_t fdKey = reinterpret_cast<std::uintptr_t>(fdKeyRaw);
+    if(map.count(fdKey) > 0){
+        *fd = map.at(fdKey);
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+void* createPlatformDeviceFdKey(void* fd){
+    std::unique_lock<std::mutex> lock(mutex);
+
+    // Get uniqueFdKey
+    std::uintptr_t fdKey = uniqueFdKey++;
+    map[fdKey] = fd;
+    return reinterpret_cast<void*>(fdKey);
+}
+
+int destroyPlatformDeviceFdKey(void* fdKeyRaw){
+    std::unique_lock<std::mutex> lock(mutex);
+
+    std::uintptr_t fdKey = reinterpret_cast<std::uintptr_t>(fdKeyRaw);
+    if(map.count(fdKey) > 0){
+        map.erase(fdKey);
+        return 0;
+    } else {
+        return -1;
+    }
+}

--- a/src/pc/PlatformDeviceFd.h
+++ b/src/pc/PlatformDeviceFd.h
@@ -1,0 +1,17 @@
+#ifndef _PLATFORM_DEVICE_FD_H_
+#define _PLATFORM_DEVICE_FD_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd);
+void* createPlatformDeviceFdKey(void* fd);
+int destroyPlatformDeviceFdKey(void* fdKeyRaw);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/shared/XLinkDispatcher.c
+++ b/src/shared/XLinkDispatcher.c
@@ -236,6 +236,8 @@ XLinkError_t DispatcherStart(xLinkDeviceHandle_t *deviceHandle)
 
     schedulerState[idx].resetXLink = 0;
     schedulerState[idx].dispatcherLinkDown = 0;
+    schedulerState[idx].dispatcherDeviceFdDown = 0;
+
     schedulerState[idx].deviceHandle = *deviceHandle;
     schedulerState[idx].schedulerId = idx;
 


### PR DESCRIPTION
2 bugs were present (with smaller statistical chances also relevant for USB devices, but leaved it out for now)
 1. `dispatcherDeviceFdDown` wasn't set back to 0 between destroying and creating a new link
 2. `XLinkFD` used to tie the underlying physical link and the scheduler is thought to be unique - but with TCP its actually a reusable FD number, where new link can get the same value soon after the previous link closes down. This caused `__rpc_main` issues as read/write events were routed to wrong physical link.

Resolved the unique XLinkFD issue by adding a map which keeps track of open physical links and assigns them an unique incrementing number instead. 

USB (AFAIK) uses a pointer to underlying structure (eg. libusb handle), which in theory can be reused as well if a new handle is allocated at same address. As we haven't seen this issue yet, I left it for now to reduce changes associated with the PR.