### PR TITLE
Move libusb include above XLink platform includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,10 @@ export(TARGETS ${TARGET_NAME} FILE "${PROJECT_NAME}Targets.cmake")
 configure_file("cmake/${PROJECT_NAME}Dependencies.cmake" ${PROJECT_NAME}Dependencies.cmake COPYONLY)
 
 # Configure config file (one for exporting build directory, one for installation)
-file(RELATIVE_PATH XLINK_DEPENDENCIES_INSTALLATION_PATH_REL "${CMAKE_CURRENT_BINARY_DIR}" "${HUNTER_INSTALL_PREFIX}")
+if(${HUNTER_INSTALL_PREFIX})
+    file(RELATIVE_PATH XLINK_DEPENDENCIES_INSTALLATION_PATH_REL "${CMAKE_CURRENT_BINARY_DIR}" "${HUNTER_INSTALL_PREFIX}")
+endif()
+
 configure_file(cmake/${PROJECT_NAME}Config.cmake.in ${PROJECT_NAME}Config.cmake @ONLY)
 
 # Config for installation

--- a/src/pc/PlatformData.c
+++ b/src/pc/PlatformData.c
@@ -163,7 +163,7 @@ int pciePlatformWrite(void *f, void *data, int size)
     {
         write_pending = 1;
 
-        size_t chunk = size < CHUNK_SIZE_BYTES ? size : CHUNK_SIZE_BYTES;
+        size_t chunk = (size_t)size < CHUNK_SIZE_BYTES ? (size_t)size : CHUNK_SIZE_BYTES;
         int num_written = pcie_write(f, data, chunk);
 
         write_pending = 0;

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -1,5 +1,13 @@
 // project
 #define MVLOG_UNIT_NAME xLinkUsb
+
+// libraries
+#ifdef XLINK_LIBUSB_LOCAL
+#include <libusb.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
 #include "XLink/XLinkLog.h"
 #include "XLink/XLinkPlatform.h"
 #include "XLink/XLinkPublicDefines.h"
@@ -14,13 +22,6 @@
 #include <thread>
 #include <chrono>
 #include <cstring>
-
-// libraries
-#ifdef XLINK_LIBUSB_LOCAL
-#include <libusb.h>
-#else
-#include <libusb-1.0/libusb.h>
-#endif
 
 constexpr static int MAXIMUM_PORT_NUMBERS = 7;
 using VidPid = std::pair<uint16_t, uint16_t>;


### PR DESCRIPTION
PlatformData.c:
Cast size to size_t in chunk size initialization to avoid sign compare error in
comparison.

CMakeLists.txt:
Support specifying XLINK_LIBUSB_LOCAL D flag (results in no hunter dependencies
being needed for building).