### PR TITLE
add control of libusb DLL on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ include(cmake/XLinkDependencies.cmake)
 
 # Link to libusb
 target_link_libraries(${TARGET_NAME} PRIVATE usb-1.0)
+if(WIN32 AND NOT MINGW)
+    target_link_libraries(${TARGET_NAME} PRIVATE delayimp.lib Pathcch.lib)
+    # workaround https://gitlab.kitware.com/cmake/cmake/-/issues/20022
+    target_link_options(${TARGET_NAME} PUBLIC "$<LINK_ONLY:/DELAYLOAD:libusb-1.0$<$<CONFIG:Debug>:d>.dll>")
+endif()
 
 if(WIN32)
     target_compile_definitions(${TARGET_NAME} PRIVATE WIN32_LEAN_AND_MEAN)

--- a/cmake/XLink.cmake
+++ b/cmake/XLink.cmake
@@ -16,7 +16,8 @@ if(WIN32)
     set(XLINK_PLATFORM_INCLUDE ${XLINK_ROOT_DIR}/src/pc/Win/include)
 
     file(GLOB XLINK_PLATFORM_SRC "${XLINK_ROOT_DIR}/src/pc/Win/src/*.c")
-    list(APPEND XLINK_SOURCES ${XLINK_PLATFORM_SRC})
+    file(GLOB XLINK_PLATFORM_SRC_CPP "${XLINK_ROOT_DIR}/src/pc/Win/src/*.cpp")
+    list(APPEND XLINK_SOURCES ${XLINK_PLATFORM_SRC} ${XLINK_PLATFORM_SRC_CPP})
 endif()
 
 if(APPLE)

--- a/include/XLink/XLinkPlatform.h
+++ b/include/XLink/XLinkPlatform.h
@@ -38,7 +38,7 @@ typedef enum {
 // Device management. Begin.
 // ------------------------------------
 
-void XLinkPlatformInit(void* options);
+xLinkPlatformErrorCode_t XLinkPlatformInit(void* options);
 
 #ifndef __DEVICE__
 /**

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -85,9 +85,11 @@ static int tcpipPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char*
 // XLinkPlatform API implementation. Begin.
 // ------------------------------------
 
-void XLinkPlatformInit(void* options)
+xLinkPlatformErrorCode_t XLinkPlatformInit(void* options)
 {
-    usbInitialize(options);
+    // check for failed initialization; LIBUSB_SUCCESS = 0
+    if (usbInitialize(options) != 0)
+        return X_LINK_PLATFORM_DRIVER_NOT_LOADED;
 
     // TODO(themarpe) - move to tcpip_host
     //tcpipInitialize();
@@ -95,6 +97,7 @@ void XLinkPlatformInit(void* options)
     WSADATA wsa_data;
     WSAStartup(MAKEWORD(2,2), &wsa_data);
 #endif
+    return X_LINK_PLATFORM_SUCCESS;
 }
 
 

--- a/src/pc/Win/src/win_usb_host.cpp
+++ b/src/pc/Win/src/win_usb_host.cpp
@@ -1,0 +1,74 @@
+// Win32 api and MSVC only; not mingw, *nix, etc.
+#if defined(_WIN32) && defined(_MSC_VER)
+
+// project
+#define MVLOG_UNIT_NAME xLinkUsb
+
+// libraries
+#ifdef XLINK_LIBUSB_LOCAL
+#include <libusb.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
+#include "XLink/XLinkLog.h"
+#include "usb_host.h"
+
+// std
+#include <array>
+#include <pathcch.h>
+
+int usbInitialize_customdir(void** hContext) {
+    // get handle to the module containing a XLink static function/var
+    // can not use GetModuleFileNameW(nullptr) because when the main depthai app is a DLL (e.g. plugin),
+    // then it returns the main EXE which is usually wrong
+    HMODULE hXLink = nullptr;
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCWSTR)&MVLOGLEVEL(global), &hXLink) == 0) {
+        return LIBUSB_ERROR_OVERFLOW;
+    }
+
+    // get path to that module
+    std::array<wchar_t, 2048> rawPath = {};
+    const auto len = GetModuleFileNameW(hXLink, rawPath.data(), static_cast<DWORD>(rawPath.size()));
+    if ((len == 0) || (len == rawPath.size())) {
+        return LIBUSB_ERROR_OVERFLOW;
+    }
+
+    // remove filename with string::find_last_of(), _wsplitpath_s(), PathCchRemoveFileSpec()
+    // using PathCchRemoveFileSpec() as it handles special cases
+    if (PathCchRemoveFileSpec(rawPath.data(), rawPath.size()) != S_OK) {
+        return LIBUSB_ERROR_OVERFLOW;
+    }
+
+    // persist existing custom DLL load path
+    bool oldGetError = false;
+    std::array<wchar_t, 2048> oldDllDir = {};
+    if (GetDllDirectoryW(static_cast<DWORD>(oldDllDir.size()), oldDllDir.data())) {
+        // nothing
+    }
+    else {
+        // SetDllDirectoryW() previously unused, or an error
+        oldGetError = true;
+    }
+
+    // set custom dll load directory
+    if (SetDllDirectoryW(rawPath.data()) == 0) {
+        return LIBUSB_ERROR_OVERFLOW;
+    }
+
+    // initialize libusb
+    int initResult = LIBUSB_SUCCESS;
+    __try {
+        initResult = libusb_init((libusb_context**)hContext);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        initResult = LIBUSB_ERROR_OVERFLOW;
+    }
+
+    // restore custom dll load directory
+    SetDllDirectoryW(oldGetError ? nullptr : oldDllDir.data());
+
+    return initResult;
+}
+
+#endif // defined(_WIN32) && defined(_MSC_VER)

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -75,6 +75,9 @@ int usbInitialize(void* options){
     // // Debug
     // mvLogLevelSet(MVLOG_DEBUG);
 
+    #if defined(_WIN32) && defined(_MSC_VER)
+        return usbInitialize_customdir((void**)&context);
+    #endif
     return libusb_init(&context);
 }
 

--- a/src/pc/protocols/usb_host.h
+++ b/src/pc/protocols/usb_host.h
@@ -36,6 +36,7 @@ typedef enum usbBootError {
 } usbBootError_t;
 
 int usbInitialize(void* options);
+int usbInitialize_customdir(void** hContext);
 
 int usb_boot(const char *addr, const void *mvcmd, unsigned size);
 int get_pid_by_name(const char* name);


### PR DESCRIPTION
NOT READY FOR MERGE

This PR controls the location in which Windows searches+loads the libusb DLL.
The libusb DLL should be in the same folder as the binary code that is/contains XLink. The primary config of depthai-core is to have a static XLink that is linked into depthai-core. Therefore...

1. If you have shared lib (aka DLL) of depthai-core, then libusb DLL should be in the same folder as depthai-core.dll
2. If you have static lib depthai-core, then your main app "contains" depthai-core. Then, libusb DLL should be in the same folder as your main app.
3. If you customed and compiled your own depthai-core so that XLink is a separate shared lib (aka DLL), then libusb DLL should be in the same folder as XLink.dll. This is probably a rare scenario.

### Approach

* uses Windows delay-load https://docs.microsoft.com/en-us/cpp/build/reference/linker-support-for-delay-loaded-dlls?view=msvc-170
* best/needs small changes to depthai-core in https://github.com/luxonis/depthai-core/pull/473 otherwise you might get warnings or compile error on main app that it can't find the libusb DLL during compile
* briefly tested with xlink test exe, a few depthai-core test exe's, and my app
* added error handling and error returns. I believe this is needed to successfully bubble up errors from xlink and libusb so they eventually cascade back and are thrown as exceptions to apps. I tested this with my app and it nicely bubbled up to src\utility\Initialization.cpp line 101 and threw on 103 which my app successfully caught and reported to the user.
* I've still got debug logs, some comments and questions in the code. Will remove/clean as I get feedback.