### PR TITLE
Add Android logging dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,11 @@ if(MINGW)
     )
 endif()
 
+if(ANDROID)
+    find_library(log-lib log)
+    target_link_libraries(${TARGET_NAME} PRIVATE ${log-lib})
+endif()
+
 # Create public "interface" library (no linking)
 add_library(${TARGET_PUBLIC_NAME} INTERFACE)
 target_include_directories(${TARGET_PUBLIC_NAME} INTERFACE


### PR DESCRIPTION
Fixes issue mentioned here: https://github.com/luxonis/depthai-core/issues/505

I tested this with https://github.com/ibaiGorordo/depthai-android-jni-example replacing the libdepthai-core.so and depthai+xlink includes with what I built locally using this fix with depthai-core v2.16.0 and it seemed to work fine