### PR TITLE
remove dup decrement for TCPIP device searches

### DIFF
--- a/src/pc/PlatformDeviceSearch.c
+++ b/src/pc/PlatformDeviceSearch.c
@@ -115,7 +115,6 @@ xLinkPlatformErrorCode_t XLinkPlatformFindDevices(const deviceDesc_t in_deviceRe
                 TCPIP_rc = getTcpIpDevices(in_deviceRequirements, out_foundDevices, sizeFoundDevices, &numFoundDevices);
                 *out_amountOfFoundDevices += numFoundDevices;
                 out_foundDevices += numFoundDevices;
-                sizeFoundDevices -= numFoundDevices;
                 // Found enough devices, return
                 if (numFoundDevices >= sizeFoundDevices) {
                     return X_LINK_PLATFORM_SUCCESS;


### PR DESCRIPTION
fix luxonis/XLink#56 buy removing the duplicate decrement of `sizeFoundDevices`

I also caution that `src\pc\PlatformDeviceSearch.c` lines 89 and 120 are missing a dangerous scenario. If `numFoundDevices > sizeFoundDevices` that means that memory was overwritten/corrupted. That scenario must never occur. This PR does not address that danger.

