### PR TITLE
c++ wrapper for libusb, add try/catch to prevent app crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
 endif()
 
 if(WIN32)
-    target_compile_definitions(${TARGET_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
+    target_compile_definitions(${TARGET_NAME} PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
 else()
     find_package(Threads REQUIRED)
     target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,15 +140,15 @@ endif()
 
 # Set C99 standard
 set_property(TARGET ${TARGET_NAME} PROPERTY C_STANDARD 99)
-# Set compiler features (c++11), and disables extensions (g++11)
-set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 11)
+# Set compiler features (c++14), and disables extensions (g++14)
+set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 14)
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${TARGET_NAME} PROPERTY CXX_EXTENSIONS OFF)
-# Add interface transitive property (C++11) to public library
+# Add interface transitive property (C++14) to public library
 if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
-    target_compile_features(${TARGET_PUBLIC_NAME} INTERFACE cxx_range_for)
+    target_compile_features(${TARGET_PUBLIC_NAME} INTERFACE cxx_generic_lambdas)
 else()
-    target_compile_features(${TARGET_PUBLIC_NAME} INTERFACE cxx_std_11)
+    target_compile_features(${TARGET_PUBLIC_NAME} INTERFACE cxx_std_14)
 endif()
 
 # Add flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # With additions of Luxonis
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
@@ -152,6 +152,7 @@ else()
 endif()
 
 # Add flags
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_default_flags(${TARGET_NAME})
 
 # Check if pthread_getname_np exists

--- a/cmake/Flags.cmake
+++ b/cmake/Flags.cmake
@@ -1,13 +1,19 @@
 ## setup compilation flags
 # conditionally applies flag. If flag is supported by current compiler, it will be added to compile options.
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 function(add_flag target flag)
     check_c_compiler_flag(${flag} FLAG_${flag})
     if (FLAG_${flag} EQUAL 1)
         target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:${flag}>)
     endif ()
+    check_cxx_compiler_flag(${flag} FLAGXX_${flag})
+    if (FLAGXX_${flag} EQUAL 1)
+        target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${flag}>)
+    endif ()
 endfunction()
 
+# only works for C source files
 function(add_flag_source source flag)
     check_c_compiler_flag(${flag} FLAG_${flag})
     if (FLAG_${flag} EQUAL 1)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 macro(add_example example_name example_src)
     add_executable(${example_name} ${example_src})
     target_link_libraries(${example_name} ${TARGET_NAME})
-    set_property(TARGET ${example_name} PROPERTY CXX_STANDARD 11)
+    set_property(TARGET ${example_name} PROPERTY CXX_STANDARD 14)
     set_property(TARGET ${example_name} PROPERTY CXX_STANDARD_REQUIRED ON)
     set_property(TARGET ${example_name} PROPERTY CXX_EXTENSIONS OFF)
 

--- a/include/XLink/XLinkErrorUtils.h
+++ b/include/XLink/XLinkErrorUtils.h
@@ -15,7 +15,7 @@ extern "C"
     #ifndef ASSERT_XLINK
     #define ASSERT_XLINK(condition) do { \
             if(!(condition)) { \
-                mvLog(MVLOG_ERROR, "Assertion Failed: %s \n", #condition); \
+                mvLog(MVLOG_ERROR, "Assertion Failed: %s", #condition); \
                 return X_LINK_ERROR; \
             } \
         } while(0)
@@ -26,7 +26,7 @@ extern "C"
     #ifndef ASSERT_XLINK
     #define ASSERT_XLINK(condition) do { \
             if(!(condition)) { \
-                mvLog(MVLOG_ERROR, "Assertion Failed: %s \n", #condition); \
+                mvLog(MVLOG_ERROR, "Assertion Failed: %s", #condition); \
                 exit(EXIT_FAILURE); \
             } \
         } while(0)
@@ -88,7 +88,7 @@ extern "C"
 #define XLINK_OUT_IF(condition) do { \
         \
         XLINK_OUT_WITH_LOG_IF((condition), \
-            mvLog(MVLOG_ERROR, "Condition failed: %s \n", #condition));\
+            mvLog(MVLOG_ERROR, "Condition failed: %s", #condition));\
         \
     } while(0)
 #endif  // XLINK_OUT_IF

--- a/include/XLink/XLinkLog.h
+++ b/include/XLink/XLinkLog.h
@@ -44,12 +44,18 @@ typedef enum mvLog_t{
     MVLOG_LAST,
 } mvLog_t;
 
-// Windows-only
-#if (defined (WINNT) || defined(_WIN32) || defined(_WIN64) )
-#define __attribute__(x)
-#define FUNCATTR_WEAK static
+// attribute directive support test
+#if defined(__has_attribute)
+#  define MVLOG_ATTRIBUTE(x) __attribute__(x)
+// weak function support test
+#  if __has_attribute(weak)
+#    define FUNCATTR_WEAK
+#  else
+#    define FUNCATTR_WEAK static
+#  endif
 #else
-#define FUNCATTR_WEAK
+#  define MVLOG_ATTRIBUTE(x)
+#  define FUNCATTR_WEAK static
 #endif
 
 #define _MVLOGLEVEL(UNIT_NAME)  mvLogLevel_ ## UNIT_NAME
@@ -61,7 +67,7 @@ typedef enum mvLog_t{
 #ifndef MVLOG_UNIT_NAME
 #define MVLOG_UNIT_NAME global
 #else
-FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG_LAST;
+FUNCATTR_WEAK mvLog_t MVLOG_ATTRIBUTE((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG_LAST;
 #endif
 
 
@@ -75,7 +81,7 @@ FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG
 extern mvLog_t MVLOGLEVEL(global);
 extern mvLog_t MVLOGLEVEL(default);
 
-int __attribute__ ((unused)) logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line, const char * format, ...);
+int MVLOG_ATTRIBUTE((unused)) logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line, const char * format, ...);
 
 #define mvLog(lvl, format, ...)                              \
     logprintf(MVLOGLEVEL(MVLOG_UNIT_NAME), lvl, __func__, __LINE__, format, ##__VA_ARGS__)

--- a/include/XLink/XLinkPlatformErrorUtils.h
+++ b/include/XLink/XLinkPlatformErrorUtils.h
@@ -15,7 +15,7 @@ extern "C"
     #ifndef ASSERT_XLINK_PLATFORM_R
     #define ASSERT_XLINK_PLATFORM_R(condition, err) do { \
             if(!(condition)) { \
-                mvLog(MVLOG_ERROR, "Assertion Failed: %s \n", #condition); \
+                mvLog(MVLOG_ERROR, "Assertion Failed: %s", #condition); \
                 return (err); \
             } \
         } while(0)
@@ -34,7 +34,7 @@ extern "C"
     #ifndef ASSERT_XLINK_PLATFORM_R
     #define ASSERT_XLINK_PLATFORM_R(condition, err) do { \
                 if(!(condition)) { \
-                    mvLog(MVLOG_ERROR, "Assertion Failed: %s \n", #condition); \
+                    mvLog(MVLOG_ERROR, "Assertion Failed: %s", #condition); \
                     exit(EXIT_FAILURE); \
                 } \
             } while(0)

--- a/src/pc/PlatformDeviceControl.c
+++ b/src/pc/PlatformDeviceControl.c
@@ -30,7 +30,7 @@ int usbFdRead = -1;
 #include "XLinkPublicDefines.h"
 
 #define USB_LINK_SOCKET_PORT 5678
-#define UNUSED __attribute__((unused))
+#define UNUSED MVLOG_ATTRIBUTE((unused))
 
 
 static UsbSpeed_t usb_speed_enum = X_LINK_USB_SPEED_UNKNOWN;

--- a/src/pc/PlatformDeviceFd.cpp
+++ b/src/pc/PlatformDeviceFd.cpp
@@ -1,44 +1,71 @@
 #include "PlatformDeviceFd.h"
 
-#include <unordered_map>
 #include <atomic>
-#include <mutex>
 #include <cstdint>
+#include <mutex>
+#include <unordered_map>
 
 static std::mutex mutex;
 static std::unordered_map<std::uintptr_t, void*> map;
 static std::uintptr_t uniqueFdKey{0x55};
 
-int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd){
+// Returns the mapped fd value of the element with key equivalent to fdKeyRaw
+// Non-zero return value indicates failure
+int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd) noexcept {
     if(fd == nullptr) return -1;
-    std::lock_guard<std::mutex> lock(mutex);
-
-    std::uintptr_t fdKey = reinterpret_cast<std::uintptr_t>(fdKeyRaw);
-    if(map.count(fdKey) > 0){
-        *fd = map.at(fdKey);
+    try {
+        std::lock_guard<std::mutex> lock(mutex);
+        const auto result = map.find(reinterpret_cast<std::uintptr_t>(fdKeyRaw));
+        if(result == map.end())
+            return 1;
+        *fd = result->second;
         return 0;
-    } else {
-        return 1;
-    }
-}
-
-void* createPlatformDeviceFdKey(void* fd){
-    std::lock_guard<std::mutex> lock(mutex);
-
-    // Get uniqueFdKey
-    std::uintptr_t fdKey = uniqueFdKey++;
-    map[fdKey] = fd;
-    return reinterpret_cast<void*>(fdKey);
-}
-
-int destroyPlatformDeviceFdKey(void* fdKeyRaw){
-    std::lock_guard<std::mutex> lock(mutex);
-
-    std::uintptr_t fdKey = reinterpret_cast<std::uintptr_t>(fdKeyRaw);
-    if(map.count(fdKey) > 0){
-        map.erase(fdKey);
-        return 0;
-    } else {
+    } catch(std::exception&) {
         return -1;
     }
 }
+
+// Inserts a copy of value fd into an associative container with key fdKeyRaw
+// nullptr return value indicates failure
+void* createPlatformDeviceFdKey(void* fd) noexcept {
+    try {
+        std::lock_guard<std::mutex> lock(mutex);
+        std::uintptr_t fdKey = uniqueFdKey++; // Get a unique key
+        map[fdKey] = fd;
+        return reinterpret_cast<void*>(fdKey);
+    } catch(std::exception&) {
+        return nullptr;
+    }
+}
+
+// Removes the element (if one exists) with the key equivalent to fdKeyRaw
+// Non-zero return value indicates failure
+int destroyPlatformDeviceFdKey(void* fdKeyRaw) noexcept {
+    try {
+        std::lock_guard<std::mutex> lock(mutex);
+        return !map.erase(reinterpret_cast<std::uintptr_t>(fdKeyRaw));
+    } catch(std::exception&) {
+        return -1;
+    }
+}
+
+// Extracts (finds and removes) the element (if one exists) with the key equivalent to fdKeyRaw
+// nullptr return value indicates failure
+// This atomic operation prevents a set of race conditions of two threads each get() and/or destroy()
+// keys in unpredictable orders.
+void* extractPlatformDeviceFdKey(void* fdKeyRaw) noexcept {
+    try {
+        std::lock_guard<std::mutex> lock(mutex);
+        const auto result = map.find(reinterpret_cast<std::uintptr_t>(fdKeyRaw));
+        if(result == map.end())
+            return nullptr;
+        const auto fd = result->second;
+        map.erase(result);
+        return fd;
+    } catch(std::exception&) {
+        return nullptr;
+    }
+}
+
+// TODO consider storing the device_handle in the fdKey store with std::map<device_handle> so that
+// it can automatically handle refcounting, interfaces, and closing

--- a/src/pc/PlatformDeviceFd.cpp
+++ b/src/pc/PlatformDeviceFd.cpp
@@ -1,4 +1,7 @@
+#define MVLOG_UNIT_NAME xLinkUsb
+
 #include "PlatformDeviceFd.h"
+#include "XLink/XLinkLog.h"
 
 #include <atomic>
 #include <cstdint>
@@ -12,6 +15,7 @@ static std::uintptr_t uniqueFdKey{0x55};
 // Returns the mapped fd value of the element with key equivalent to fdKeyRaw
 // Non-zero return value indicates failure
 int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd) noexcept {
+    mvLog(MVLOG_FATAL, "getPlatformDeviceFdFromKey(%p, %p)", fdKeyRaw, fd);
     if(fd == nullptr) return -1;
     try {
         std::lock_guard<std::mutex> lock(mutex);
@@ -28,6 +32,7 @@ int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd) noexcept {
 // Inserts a copy of value fd into an associative container with key fdKeyRaw
 // nullptr return value indicates failure
 void* createPlatformDeviceFdKey(void* fd) noexcept {
+    mvLog(MVLOG_FATAL, "createPlatformDeviceFdKey(%p)", fd);
     try {
         std::lock_guard<std::mutex> lock(mutex);
         std::uintptr_t fdKey = uniqueFdKey++; // Get a unique key
@@ -41,6 +46,7 @@ void* createPlatformDeviceFdKey(void* fd) noexcept {
 // Removes the element (if one exists) with the key equivalent to fdKeyRaw
 // Non-zero return value indicates failure
 int destroyPlatformDeviceFdKey(void* fdKeyRaw) noexcept {
+    mvLog(MVLOG_FATAL, "destroyPlatformDeviceFdKey(%p)", fdKeyRaw);
     try {
         std::lock_guard<std::mutex> lock(mutex);
         return !map.erase(reinterpret_cast<std::uintptr_t>(fdKeyRaw));
@@ -54,6 +60,7 @@ int destroyPlatformDeviceFdKey(void* fdKeyRaw) noexcept {
 // This atomic operation prevents a set of race conditions of two threads each get() and/or destroy()
 // keys in unpredictable orders.
 void* extractPlatformDeviceFdKey(void* fdKeyRaw) noexcept {
+    mvLog(MVLOG_FATAL, "extractPlatformDeviceFdKey(%p)", fdKeyRaw);
     try {
         std::lock_guard<std::mutex> lock(mutex);
         const auto result = map.find(reinterpret_cast<std::uintptr_t>(fdKeyRaw));

--- a/src/pc/PlatformDeviceFd.h
+++ b/src/pc/PlatformDeviceFd.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd) NOEXCEPT;
+void* getPlatformDeviceFdFromKeySimple(void* fdKeyRaw) NOEXCEPT;
 void* createPlatformDeviceFdKey(void* fd) NOEXCEPT;
 int destroyPlatformDeviceFdKey(void* fdKeyRaw) NOEXCEPT;
 void* extractPlatformDeviceFdKey(void* fdKeyRaw) NOEXCEPT;

--- a/src/pc/PlatformDeviceFd.h
+++ b/src/pc/PlatformDeviceFd.h
@@ -2,13 +2,16 @@
 #define _PLATFORM_DEVICE_FD_H_
 
 #ifdef __cplusplus
-extern "C"
-{
+#define NOEXCEPT noexcept
+extern "C" {
+#else
+#define NOEXCEPT
 #endif
 
-int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd);
-void* createPlatformDeviceFdKey(void* fd);
-int destroyPlatformDeviceFdKey(void* fdKeyRaw);
+int getPlatformDeviceFdFromKey(void* fdKeyRaw, void** fd) NOEXCEPT;
+void* createPlatformDeviceFdKey(void* fd) NOEXCEPT;
+int destroyPlatformDeviceFdKey(void* fdKeyRaw) NOEXCEPT;
+void* extractPlatformDeviceFdKey(void* fdKeyRaw) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/src/pc/PlatformDeviceSearchDynamic.cpp
+++ b/src/pc/PlatformDeviceSearchDynamic.cpp
@@ -19,7 +19,7 @@
 
 extern "C" xLinkPlatformErrorCode_t getUSBDevices(const deviceDesc_t in_deviceRequirements,
                                                      deviceDesc_t* out_foundDevices, int sizeFoundDevices,
-                                                     unsigned int *out_amountOfFoundDevices);
+                                                     unsigned int *out_amountOfFoundDevices) noexcept;
 
 xLinkPlatformErrorCode_t XLinkPlatformFindDevicesDynamic(const deviceDesc_t in_deviceRequirements,
                                                      deviceDesc_t* out_foundDevices, unsigned sizeFoundDevices,

--- a/src/pc/PlatformDeviceSearchDynamic.cpp
+++ b/src/pc/PlatformDeviceSearchDynamic.cpp
@@ -138,9 +138,9 @@ xLinkPlatformErrorCode_t XLinkPlatformFindDevicesDynamic(const deviceDesc_t in_d
         {
             deviceDesc_t* devices = out_foundDevices;
             int write_index = 0;
-            for(int i = 0; i < *out_amountOfFoundDevices; i++){
+            for(int i = 0, amountBound = static_cast<int>(*out_amountOfFoundDevices); i < amountBound; ++i){
                 bool duplicate = false;
-                for(int j = i - 1; j >= 0; j--){
+                for(int j = i - 1; j >= 0; --j){
                     // Check if duplicate
                     if(devices[i].protocol == devices[j].protocol && strcmp(devices[i].name, devices[j].name) == 0 && strcmp(devices[i].mxid, devices[j].mxid) == 0){
                         duplicate = true;

--- a/src/pc/Win/src/win_usb_host.cpp
+++ b/src/pc/Win/src/win_usb_host.cpp
@@ -18,7 +18,8 @@
 #include <array>
 #include <pathcch.h>
 
-int usbInitialize_customdir(void** hContext) {
+// support Visual C++ compiler for Windows to load libusb DLL from the same directory as the XLink code
+libusb_error usbInitializeCustomdir(libusb_context ** hContext) noexcept {
     // get handle to the module containing a XLink static function/var
     // can not use GetModuleFileNameW(nullptr) because when the main depthai app is a DLL (e.g. plugin),
     // then it returns the main EXE which is usually wrong
@@ -57,9 +58,9 @@ int usbInitialize_customdir(void** hContext) {
     }
 
     // initialize libusb
-    int initResult = LIBUSB_SUCCESS;
+    libusb_error initResult = LIBUSB_SUCCESS;
     __try {
-        initResult = libusb_init((libusb_context**)hContext);
+        initResult = static_cast<libusb_error>(libusb_init(hContext));
     }
     __except (EXCEPTION_EXECUTE_HANDLER) {
         initResult = LIBUSB_ERROR_OVERFLOW;

--- a/src/pc/protocols/pcie_host.c
+++ b/src/pc/protocols/pcie_host.c
@@ -157,7 +157,7 @@ int pcie_write(HANDLE fd, void * buf, size_t bufSize)
     Event = CreateEvent(NULL, TRUE, FALSE, NULL);
 
     if (Event == NULL) {
-        mvLog(MVLOG_INFO, "Error creating I/O event for pcie_write - 0x%x\n", GetLastError());
+        mvLog(MVLOG_INFO, "Error creating I/O event for pcie_write - 0x%x", GetLastError());
         return PCIE_HOST_ERROR;
     }
 
@@ -174,7 +174,7 @@ int pcie_write(HANDLE fd, void * buf, size_t bufSize)
                 mvLog(MVLOG_DEBUG, "WriteFile GetOverlappedResult failed");
             }
         } else {
-            mvLog(MVLOG_DEBUG, "WriteFile failed with error code = 0x%x \n", GetLastError());
+            mvLog(MVLOG_DEBUG, "WriteFile failed with error code = 0x%x", GetLastError());
         }
     } else {
         mvLog(MVLOG_DEBUG, "fOverlapped - operation complete immediately");
@@ -233,7 +233,7 @@ int pcie_read(HANDLE fd, void * buf, size_t bufSize)
     Event = CreateEvent(NULL, TRUE, FALSE, NULL);
 
     if (Event == NULL) {
-        mvLog(MVLOG_ERROR, "Error creating I/O event for pcie_read - 0x%x\n", GetLastError());
+        mvLog(MVLOG_ERROR, "Error creating I/O event for pcie_read - 0x%x", GetLastError());
         return PCIE_HOST_ERROR;
     }
 
@@ -251,7 +251,7 @@ int pcie_read(HANDLE fd, void * buf, size_t bufSize)
                mvLog(MVLOG_DEBUG, "ReadFile GetOverlappedResult failed" );
             }
         } else {
-            mvLog(MVLOG_DEBUG, "ReadFile failed with error code = 0x%x \n", GetLastError());
+            mvLog(MVLOG_DEBUG, "ReadFile failed with error code = 0x%x", GetLastError());
         }
     } else {
          mvLog(MVLOG_DEBUG, "fOverlapped - operation complete immediately");
@@ -559,7 +559,7 @@ pcieHostError_t pcie_boot_device(HANDLE fd, const char  *buffer, size_t length)
 
         int resetDeviceRC = pcie_reset_device(fd);
         if (resetDeviceRC) {
-            mvLog(MVLOG_ERROR, "Device resetting failed with error: %d\n", resetDeviceRC);
+            mvLog(MVLOG_ERROR, "Device resetting failed with error: %d", resetDeviceRC);
             return resetDeviceRC;
         }
     }

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -228,15 +228,18 @@ extern "C" xLinkPlatformErrorCode_t refLibusbDeviceByName(const char* path, libu
     }
 
     // Get list of usb devices
-    const auto deviceList = device_list::create(context);
-    if(!deviceList) {
+    device_list deviceList;
+    try {
+        deviceList = device_list{context};
+    }
+    catch(const std::exception&) {
         return X_LINK_PLATFORM_ERROR;
     }
 
     // Loop over all usb devices, increase count only if myriad device that matches the name
     // TODO does not filter by myriad devices, investigate if needed
     const std::string requiredPath(path);
-    for (auto* const usbDevice : *deviceList) {
+    for (auto* const usbDevice : deviceList) {
         if(usbDevice == nullptr) continue;
 
         // compare device path with name

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -25,6 +25,7 @@
 #include <tuple>
 #include <chrono>
 #include <cstring>
+#include <cassert>
 
 using dp::libusb::config_descriptor;
 using dp::libusb::device_handle;
@@ -152,8 +153,8 @@ extern "C" xLinkPlatformErrorCode_t getUSBDevices(const deviceDesc_t deviceRequi
         span<deviceDesc_t> foundDevices{foundDevicesBuffer, static_cast<size_t>(sizeFoundDevicesBufferEntities)};
         auto* foundDevice = foundDevices.begin();
         for (const auto candidateDevice : deviceList) {
-            // skip invalid devices https://github.com/libusb/libusb/issues/1287
-            if(!candidateDevice) continue;
+            // disallow invalid devices https://github.com/libusb/libusb/issues/1287
+            assert(candidateDevice);
 
             // setup device i/o and query device
             try {
@@ -258,8 +259,8 @@ usb_device acquireDeviceByPath(const char* const path) {
         // Loop over all usb devices
         const std::string requiredPath(path);
         for(auto candidateDevice : deviceList) {
-            // skip invalid devices https://github.com/libusb/libusb/issues/1287
-            if(!candidateDevice) continue;
+            // disallow invalid devices https://github.com/libusb/libusb/issues/1287
+            assert(candidateDevice);
 
             // compare device path with required path
             if(requiredPath == getLibusbDevicePath(candidateDevice)) {

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -108,6 +108,8 @@ static constexpr std::array<std::pair<VidPid, XLinkDeviceState_t>, 4> VID_PID_TO
     {{0x03E7, 0xf63d}, X_LINK_FLASH_BOOTED},
 }};
 
+static_assert(VID_PID_TO_DEVICE_STATE.size() == 4, "VID_PID_TO_DEVICE_STATE size mismatch");
+
 static std::string getLibusbDevicePath(const usb_device&);
 static libusb_error getLibusbDeviceMxId(XLinkDeviceState_t state, const std::string& devicePath, const libusb_device_descriptor* pDesc, const usb_device& device, std::string& outMxId);
 static const char* xlink_libusb_strerror(ssize_t);

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -508,11 +508,10 @@ static libusb_error usb_open_device(const usb_device& dev, uint8_t* endpoint, de
         handle.claim_interface(0);
 
         // Get device config descriptor
-        config_descriptor cdesc{dev.get(), 0};
+        const auto cdesc = dev.get_config_descriptor(0);
 
-        const struct libusb_interface_descriptor *ifdesc;
-        ifdesc = cdesc->interface->altsetting;
         // TODO add endpoint pointer boundary checks
+        const struct libusb_interface_descriptor *ifdesc = cdesc->interface->altsetting;
         for(int i=0; i<ifdesc->bNumEndpoints; i++)
         {
             mvLog(MVLOG_DEBUG, "Found EP 0x%02x : max packet size is %u bytes",

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -377,7 +377,7 @@ libusb_error getLibusbDeviceMxId(const XLinkDeviceState_t state, const std::stri
                     // TODO consider sharing this whole block of code with openConfigClaimDevice()
                     const auto active_configuration = handle.get_configuration<MVLOG_DEBUG>();
                     if(active_configuration != 1){
-                        mvLog(MVLOG_DEBUG, "Setting configuration from %d to 1\n", active_configuration);
+                        mvLog(MVLOG_DEBUG, "Setting configuration from %d to 1", active_configuration);
                         handle.set_configuration(1);
                     }
 
@@ -626,7 +626,7 @@ int usbPlatformConnect(const char* const devPathRead, const char* const devPathW
 
     if (connect(usbFdWrite, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0)
     {
-        mvLog(MVLOG_ERROR, "connect(usbFdWrite,...) returned < 0\n");
+        mvLog(MVLOG_ERROR, "connect(usbFdWrite,...) returned < 0");
         if (usbFdRead >= 0)
             close(usbFdRead);
         if (usbFdWrite >= 0)

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -355,7 +355,7 @@ libusb_error getLibusbDeviceMxId(XLinkDeviceState_t state, std::string devicePat
                     }
 
                     // Set to auto detach & reattach kernel driver, and ignore result (success or not supported)
-                    libusb_set_auto_detach_kernel_driver(handle.get(), 1);
+                    handle.set_auto_detach_kernel_driver<MVLOG_INFO, false>(true);
 
                     // Claim interface (as we'll be doing IO on endpoints)
                     // TODO consider that previous C code logged with (libusb_rc == LIBUSB_ERROR_BUSY ? MVLOG_DEBUG : MVLOG_ERROR)
@@ -501,7 +501,7 @@ static libusb_error usb_open_device(const usb_device& dev, uint8_t* endpoint, de
         }
 
         // Set to auto detach & reattach kernel driver, and ignore result (success or not supported)
-        libusb_set_auto_detach_kernel_driver(handle.get(), 1);
+        handle.set_auto_detach_kernel_driver<MVLOG_INFO, false>(true);
 
         // claim interface 0
         handle.claim_interface(0);

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -403,11 +403,11 @@ libusb_error getLibusbDeviceMxId(const XLinkDeviceState_t state, const std::stri
                 std::array<uint8_t, expectedMxIdReadSize> rbuf;
                 try {
                     // WD Protection & MXID Retrieval Command
-                    handle.bulk_transfer<MVLOG_FATAL, true, MX_ID_TIMEOUT_MS>(send_ep, usb_mx_id_get_payload(), usb_mx_id_get_payload_size());
+                    handle.bulk_transfer<MVLOG_ERROR, true, MX_ID_TIMEOUT_MS>(send_ep, usb_mx_id_get_payload(), usb_mx_id_get_payload_size());
                     // MXID Read
-                    handle.bulk_transfer<MVLOG_FATAL, true, MX_ID_TIMEOUT_MS>(recv_ep, rbuf);
+                    handle.bulk_transfer<MVLOG_ERROR, true, MX_ID_TIMEOUT_MS>(recv_ep, rbuf);
                     // WD Protection end
-                    handle.bulk_transfer<MVLOG_FATAL, true, MX_ID_TIMEOUT_MS>(send_ep, usb_mx_id_get_payload_end(), usb_mx_id_get_payload_end_size());
+                    handle.bulk_transfer<MVLOG_ERROR, true, MX_ID_TIMEOUT_MS>(send_ep, usb_mx_id_get_payload_end(), usb_mx_id_get_payload_end_size());
                 }
                 catch(const usb_error& e) {
                     // Mark as error and retry
@@ -559,7 +559,7 @@ int usb_boot(const char* addr, const void* mvcmd, unsigned size) noexcept {
         const auto handleEndpoint = usbSharedOpen(addr, DEFAULT_CONNECT_TIMEOUT, true);
 
         // transfer boot binary to device
-        handleEndpoint.first.bulk_transfer<MVLOG_FATAL, true, DEFAULT_WRITE_TIMEOUT, true, DEFAULT_SEND_FILE_TIMEOUT.count()>(handleEndpoint.second, mvcmd, size);
+        handleEndpoint.first.bulk_transfer<MVLOG_ERROR, true, DEFAULT_WRITE_TIMEOUT, true, DEFAULT_SEND_FILE_TIMEOUT.count()>(handleEndpoint.second, mvcmd, size);
         return X_LINK_PLATFORM_SUCCESS;
     } catch(const usb_error& e) {
         return static_cast<int>(parseLibusbError(static_cast<libusb_error>(e.code().value())));

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -520,7 +520,7 @@ static libusb_error usb_open_device(libusb_device *dev, uint8_t* endpoint, libus
     catch(const usb_error& e) {
         return static_cast<libusb_error>(e.code().value());
     }
-    catch(const std::exception& e) {
+    catch(const std::exception&) {
         return LIBUSB_ERROR_OTHER;
     }
 

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -281,8 +281,10 @@ std::string getLibusbDevicePath(const usb_device& device) {
     // Get and append all subsequent port numbers
     const auto portNumbers = device.get_port_numbers<MVLOG_ERROR, true, MAXIMUM_PORT_NUMBERS>();
     if (portNumbers.empty()) {
-        // Shouldn't happen! Emulate previous code by appending dot
-        devicePath += '.';
+        // likely a host controller/root hub directly on PCIE on Windows; otherwise shouldn't happen
+        // https://github.com/libusb/libusb/blob/cc498ded18fb2c6e4506c546d0351c4ae91ef2cc/libusb/core.c#L955
+        // Previous code appended only a dot
+        devicePath += ".0";
     }
     else {
         // Add port numbers to path separated by a dot

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -416,17 +416,6 @@ libusb_error getLibusbDeviceMxId(const XLinkDeviceState_t state, const std::stri
                 // End
                 ///////////////////////
 
-                // Release claimed interface
-                try {
-                    handle.release_interface(0);
-                }
-                catch(const usb_error&) {
-                    // ignore error as it doesn't matter
-                }
-                catch(const std::exception&) {
-                    return LIBUSB_ERROR_OTHER;
-                }
-
                 // Parse mxId into HEX presentation
                 // There's a bug, it should be 0x0F, but setting as in MDK
                 rbuf[8] &= 0xF0;

--- a/src/pc/protocols/usb_host.h
+++ b/src/pc/protocols/usb_host.h
@@ -3,7 +3,10 @@
 //
 
 #ifdef __cplusplus
+#define NOEXCEPT noexcept
 extern "C" {
+#else
+#define NOEXCEPT
 #endif
 
 #include <stdbool.h>
@@ -38,10 +41,10 @@ typedef enum usbBootError {
 int usbInitialize(void* options);
 int usbInitialize_customdir(void** hContext);
 
-int usb_boot(const char *addr, const void *mvcmd, unsigned size);
+int usb_boot(const char *addr, const void *mvcmd, unsigned size) NOEXCEPT;
 int get_pid_by_name(const char* name);
 
-xLinkPlatformErrorCode_t usbLinkBootBootloader(const char* path);
+xLinkPlatformErrorCode_t usbLinkBootBootloader(const char* path) NOEXCEPT;
 int usbPlatformConnect(const char *devPathRead, const char *devPathWrite, void **fd);
 int usbPlatformClose(void *fd);
 int usbPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, size_t length);

--- a/src/pc/protocols/usb_host.h
+++ b/src/pc/protocols/usb_host.h
@@ -38,8 +38,7 @@ typedef enum usbBootError {
     USB_BOOT_TIMEOUT
 } usbBootError_t;
 
-int usbInitialize(void* options);
-int usbInitialize_customdir(void** hContext);
+int usbInitialize(void* options) NOEXCEPT;
 
 int usb_boot(const char *addr, const void *mvcmd, unsigned size) NOEXCEPT;
 int get_pid_by_name(const char* name);

--- a/src/pc/protocols/usb_host.h
+++ b/src/pc/protocols/usb_host.h
@@ -44,12 +44,12 @@ int usb_boot(const char *addr, const void *mvcmd, unsigned size) NOEXCEPT;
 int get_pid_by_name(const char* name);
 
 xLinkPlatformErrorCode_t usbLinkBootBootloader(const char* path) NOEXCEPT;
-int usbPlatformConnect(const char *devPathRead, const char *devPathWrite, void **fd);
-int usbPlatformClose(void *fd);
-int usbPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, size_t length);
+int usbPlatformConnect(const char *devPathRead, const char *devPathWrite, void **fd) NOEXCEPT;
+int usbPlatformClose(void *fd) NOEXCEPT;
+int usbPlatformBootFirmware(const deviceDesc_t* deviceDesc, const char* firmware, size_t length) NOEXCEPT;
 
-int usbPlatformRead(void *fd, void *data, int size);
-int usbPlatformWrite(void *fd, void *data, int size);
+int usbPlatformRead(void *fd, void *data, int size) NOEXCEPT;
+int usbPlatformWrite(void *fd, void *data, int size) NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/src/pc/protocols/wrap_libusb.cpp
+++ b/src/pc/protocols/wrap_libusb.cpp
@@ -1,0 +1,27 @@
+/*
+    dp::libusb - C++ wrapper for libusb-1.0 (focused on use with the XLink protocol)
+
+    Copyright 2023 Dale Phurrough
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "wrap_libusb.hpp"
+
+std::mutex dp::libusb::device_list::mtx;
+
+// definition outside class to workaround Clang constexpr failures
+constexpr int dp::libusb::device_handle::DEFAULT_CHUNK_SIZE;
+constexpr int dp::libusb::device_handle::DEFAULT_CHUNK_SIZE_USB1;
+constexpr decltype(libusb_endpoint_descriptor::wMaxPacketSize) dp::libusb::device_handle::DEFAULT_MAX_PACKET_SIZE;
+constexpr std::array<decltype(libusb_endpoint_descriptor::wMaxPacketSize), 32> dp::libusb::device_handle::DEFAULT_MAX_PACKET_ARRAY;

--- a/src/pc/protocols/wrap_libusb.cpp
+++ b/src/pc/protocols/wrap_libusb.cpp
@@ -16,6 +16,17 @@
     limitations under the License.
 */
 
+// project
+#define MVLOG_UNIT_NAME xLinkUsb
+#include "XLink/XLinkLog.h"
+
+// libraries
+#ifdef XLINK_LIBUSB_LOCAL
+#include <libusb.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
 #include "wrap_libusb.hpp"
 
 std::mutex dp::libusb::device_list::mtx;

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -52,26 +52,6 @@ using usb_device = unique_resource_ptr<libusb_device, libusb_unref_device>;
 class device_list;
 class device_list {
 public:
-    static std::unique_ptr<device_list> create(libusb_context* context) noexcept {
-        static_assert(std::is_nothrow_constructible_v<device_list>, "device_list() errantly throws");
-        auto result = std::make_unique<device_list>();
-        if (result) {
-            //const auto result = std::unique_ptr<device_list>(new device_list());
-            const auto rcNum = libusb_get_device_list(context, &result->deviceList);
-            if (rcNum < 0 || result->deviceList == nullptr) {
-                mvLog(MVLOG_ERROR, "Unable to get USB device list: %s", libusb_strerror(rcNum));
-                result.reset();
-            }
-            else {
-                result->countDevices = static_cast<size_type>(rcNum);
-            }
-        }
-        else {
-            mvLog(MVLOG_ERROR, "Unable to allocate memory for USB device list");
-        }
-        return result;
-    }
-
     // default constructors, destructor, copy, move
     device_list() = default; // could be private by create() using `new device_list()`
     ~device_list() noexcept {

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -194,6 +194,10 @@ public:
     size_type size() const noexcept {
         return countDevices;
     }
+    constexpr size_type max_size() const noexcept {
+        constexpr auto MAX = std::numeric_limits<uintptr_t>::max() / sizeof(value_type);
+        return MAX;
+    }
     bool empty() const noexcept {
         return countDevices == 0;
     }
@@ -262,6 +266,20 @@ public:
             throw std::out_of_range("device_list::at");
         }
         return *(cbegin() + index);
+    }
+    void swap(device_list& other) noexcept {
+        std::swap(countDevices, other.countDevices);
+        std::swap(deviceList, other.deviceList);
+    }
+    friend void swap(device_list& left, device_list& right) noexcept {
+        left.swap(right);
+    }
+    bool operator==(const device_list& other) const noexcept {
+        // short circuit if same pointer list
+        return countDevices == other.countDevices && deviceList == other.deviceList;
+    }
+    bool operator!=(const device_list& other) const noexcept {
+        return !(*this == other);
     }
 
 private:

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -1,4 +1,6 @@
 /*
+    dp::libusb - C++ wrapper for libusb-1.0 (focused on use with the XLink protocol)
+
     Copyright 2023 Dale Phurrough
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -387,6 +387,19 @@ public:
         call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_get_device_descriptor, get(), &descriptor);
         return descriptor;
     }
+
+    // wrapper for libusb_get_bus_number()
+    uint8_t get_bus_number() const {
+        return CALL_LOG_ERROR_THROW(libusb_get_bus_number, get());
+    }
+
+    // wrapper for libusb_get_port_numbers()
+    template<mvLog_t Loglevel = MVLOG_ERROR, bool Throw = true, int Len = 7>
+    std::vector<uint8_t> get_port_numbers() const {
+        std::vector<uint8_t> numbers{Len, 0};
+        numbers.resize(call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_get_port_numbers, get(), numbers.data(), Len));
+        return numbers;
+    }
 };
 
 /*

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -140,9 +140,12 @@ public:
     // default constructors, destructor, copy, move
     device_list() = default;
     ~device_list() noexcept {
-        if (deviceList != nullptr) {
-            libusb_free_device_list(deviceList, 1);
+        // both libapi apis return when param == nullptr
+        // workaround libusb bug https://github.com/libusb/libusb/issues/1287
+        for (size_type i = 0; i < countDevices; ++i) {
+            libusb_unref_device(deviceList[i]);
         }
+        libusb_free_device_list(deviceList, 0);
     }
     device_list(const device_list&) = delete;
     device_list& operator=(const device_list&) = delete;

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -448,6 +448,12 @@ public:
     int bulk_transfer(unsigned char endpoint, void *data, int length, int *transferred, std::chrono::milliseconds timeout) const noexcept {
         return libusb_bulk_transfer(get(), endpoint, static_cast<unsigned char*>(data), length, transferred, static_cast<unsigned int>(timeout.count()));
     }
+
+    // wrapper for libusb_control_transfer()
+    template<mvLog_t Loglevel = MVLOG_ERROR, bool Throw = true>
+    int control_transfer(uint8_t requestType, uint8_t request, uint16_t value, uint16_t index, void *data, uint16_t length, std::chrono::milliseconds timeout) const noexcept(!Throw) {
+        return call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_control_transfer, get(), requestType, request, value, index, static_cast<unsigned char*>(data), length, static_cast<unsigned int>(timeout.count()));
+    }
 };
 
 class usb_device : public unique_resource_ptr<libusb_device, libusb_unref_device> {
@@ -533,7 +539,7 @@ inline std::pair<libusb_error, ptrdiff_t> device_handle::bulk_transfer(const uns
     static constexpr int DEFAULT_CHUNK_SIZE = 1024 * 1024;  // must be multiple of endpoint max packet size
     static constexpr int DEFAULT_CHUNK_SIZE_USB1 = 64;      // must be multiple of endpoint max packet size
     static constexpr bool BUFFER_IS_CONST = static_cast<bool>(std::is_const<BufferValueType>::value);
-    static constexpr auto CHUNK_TIMEOUT = (TimeoutMs == 0) ? ChunkTimeoutMs : std::min(ChunkTimeoutMs, TimeoutMs);
+    static constexpr auto CHUNK_TIMEOUT = (TimeoutMs == 0) ? ChunkTimeoutMs : details::min(ChunkTimeoutMs, TimeoutMs);
 
     std::pair<libusb_error, ptrdiff_t> result{LIBUSB_ERROR_INVALID_PARAM, 0};
 

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -19,17 +19,6 @@
 #ifndef _WRAP_LIBUSB_HPP_
 #define _WRAP_LIBUSB_HPP_
 
-// project
-#define MVLOG_UNIT_NAME xLinkUsb
-#include "XLink/XLinkLog.h"
-
-// libraries
-#ifdef XLINK_LIBUSB_LOCAL
-#include <libusb.h>
-#else
-#include <libusb-1.0/libusb.h>
-#endif
-
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -21,6 +21,7 @@
 
 // project
 #define MVLOG_UNIT_NAME xLinkUsb
+#include "XLink/XLinkLog.h"
 
 // libraries
 #ifdef XLINK_LIBUSB_LOCAL
@@ -272,9 +273,6 @@ private:
     size_type countDevices{};
     pointer deviceList{};
 };
-
-// TODO move to dedicated cpp file to avoid multiple definitions
-std::mutex device_list::mtx;
 
 // wraps libusb_config_descriptor* and automatically libusb_free_config_descriptor() on destruction
 class config_descriptor : public unique_resource_ptr<libusb_config_descriptor, libusb_free_config_descriptor> {
@@ -534,7 +532,7 @@ public:
     int control_transfer(uint8_t requestType, uint8_t request, uint16_t value, uint16_t index, void *data, uint16_t length, std::chrono::milliseconds timeout) const noexcept(!Throw) {
         return call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_control_transfer, get(), requestType, request, value, index, static_cast<unsigned char*>(data), length, static_cast<unsigned int>(timeout.count()));
     }
-    };
+};
 
 class usb_device : public unique_resource_ptr<libusb_device, libusb_unref_device> {
 private:

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -136,13 +136,13 @@ public:
     device_list(const device_list&) = delete;
     device_list& operator=(const device_list&) = delete;
     device_list(device_list&& other) noexcept :
-        countDevices{details::exchange(other.countDevices, 0)},
-        deviceList{details::exchange(other.deviceList, nullptr)} {};
+        countDevices{std::exchange(other.countDevices, 0)},
+        deviceList{std::exchange(other.deviceList, nullptr)} {};
     device_list& operator=(device_list&& other) noexcept {
         if (this == &other)
             return *this;
-        countDevices = details::exchange(other.countDevices, 0);
-        deviceList = details::exchange(other.deviceList, nullptr);
+        countDevices = std::exchange(other.countDevices, 0);
+        deviceList = std::exchange(other.deviceList, nullptr);
         return *this;
     }
 
@@ -310,13 +310,13 @@ public:
     device_handle(const device_handle&) = delete;
     device_handle& operator=(const device_handle&) = delete;
     device_handle(device_handle &&other) noexcept :
-        _base{details::exchange<_base, _base>(other, {})},
-        claimedInterfaces{details::exchange(other.claimedInterfaces, {})}
+        _base{std::exchange<_base, _base>(other, {})},
+        claimedInterfaces{std::exchange(other.claimedInterfaces, {})}
     {}
     device_handle &operator=(device_handle &&other) noexcept {
         if (this != &other) {
-            *static_cast<_base*>(this) = details::exchange<_base, _base>(other, {});
-            claimedInterfaces = details::exchange(other.claimedInterfaces, {});
+            *static_cast<_base*>(this) = std::exchange<_base, _base>(other, {});
+            claimedInterfaces = std::exchange(other.claimedInterfaces, {});
         }
         return *this;
     }
@@ -544,7 +544,7 @@ inline std::pair<libusb_error, ptrdiff_t> device_handle::bulk_transfer(const uns
     static constexpr int DEFAULT_CHUNK_SIZE = 1024 * 1024;  // must be multiple of endpoint max packet size
     static constexpr int DEFAULT_CHUNK_SIZE_USB1 = 64;      // must be multiple of endpoint max packet size
     static constexpr bool BUFFER_IS_CONST = static_cast<bool>(std::is_const<BufferValueType>::value);
-    static constexpr auto CHUNK_TIMEOUT = (TimeoutMs == 0) ? ChunkTimeoutMs : details::min(ChunkTimeoutMs, TimeoutMs);
+    static constexpr auto CHUNK_TIMEOUT = (TimeoutMs == 0) ? ChunkTimeoutMs : std::min(ChunkTimeoutMs, TimeoutMs);
 
     std::pair<libusb_error, ptrdiff_t> result{LIBUSB_ERROR_INVALID_PARAM, 0};
 

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -116,7 +116,7 @@ inline auto call_log_throw(const char* func_within, const int line_number, Func&
 using usb_device = unique_resource_ptr<libusb_device, libusb_unref_device>;
 
 // wraps libusb_context and automatically libusb_exit() on destruction
-// using context = unique_resource_ptr<libusb_context, libusb_exit>;
+ using usb_context = unique_resource_ptr<libusb_context, libusb_exit>;
 
 // device_list container class wrapper for libusb_get_device_list()
 // Use constructors to create an instance as the primary approach.

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -64,8 +64,8 @@ private:
     using _base = std::unique_ptr<Resource, unique_resource_deleter<Resource, Dispose>>;
 
 public:
-    // inherit base constructors
-    using _base::unique_ptr;
+    // inherit base constructors, long form due to Clang fail using _base
+    using std::unique_ptr<Resource, unique_resource_deleter<Resource, Dispose>>::unique_ptr;
 
     // delete base unique_resource_ptr constructors that would conflict with ref counts
     unique_resource_ptr(typename _base::pointer, const typename _base::deleter_type &) = delete;
@@ -214,8 +214,8 @@ public:
     // constructors
     ////////////////
 
-    // inherit base constructors
-    using _base::unique_resource_ptr;
+    // inherit base constructors, long form due to Clang fail using _base
+    using unique_resource_ptr<libusb_device_handle, libusb_close>::unique_resource_ptr;
 
     /// @brief Create a device_handle from a raw libusb_device_handle*
     /// @param handle raw libusb_device_handle* to wrap and manage ownership
@@ -504,8 +504,8 @@ private:
     using _base = unique_resource_ptr<libusb_device, libusb_unref_device>;
 
 public:
-    // inherit base constructors
-    using _base::unique_resource_ptr;
+    // inherit base constructors, long form due to Clang fail using _base
+    using unique_resource_ptr<libusb_device, libusb_unref_device>::unique_resource_ptr;
 
     /// @brief construct a usb_device from a raw libusb_device* pointer and shares ownership
     /// @param ptr raw libusb_device* pointer

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -314,6 +314,19 @@ public:
         CALL_LOG_ERROR_THROW(libusb_release_interface, get(), interface_number);
         claimedInterfaces.erase(candidate);
     }
+
+    // wrapper for libusb_set_configuration()
+    void set_configuration(int configuration) {
+        CALL_LOG_ERROR_THROW(libusb_set_configuration, get(), configuration);
+    }
+
+    // wrapper for libusb_get_configuration()
+    template<mvLog_t Loglevel = MVLOG_ERROR>
+    int get_configuration() {
+        int configuration{};
+        call_log_throw<Loglevel>(__func__, __LINE__, libusb_get_configuration, get(), &configuration);
+        return configuration;
+    }
 };
 
 /*

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -351,13 +351,17 @@ public:
     device_handle(const device_handle&) = delete;
     device_handle& operator=(const device_handle&) = delete;
     device_handle(device_handle &&other) noexcept :
-        _base{std::exchange<_base, _base>(other, {})},
-        claimedInterfaces{std::exchange(other.claimedInterfaces, {})}
+        _base{std::move(other)},
+        bcdUSB{std::exchange(other.bcdUSB, {})},
+        maxPacketSize{exchange_maxPacketSize(other.maxPacketSize)},
+        claimedInterfaces{std::move(other.claimedInterfaces)}
     {}
     device_handle &operator=(device_handle &&other) noexcept {
         if (this != &other) {
-            *static_cast<_base*>(this) = std::exchange<_base, _base>(other, {});
-            claimedInterfaces = std::exchange(other.claimedInterfaces, {});
+            _base::operator=(std::move(other));
+            bcdUSB = std::exchange(other.bcdUSB, {});
+            maxPacketSize = exchange_maxPacketSize(other.maxPacketSize);
+            claimedInterfaces = std::move(other.claimedInterfaces);
         }
         return *this;
     }

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -321,11 +321,17 @@ public:
     }
 
     // wrapper for libusb_get_configuration()
-    template<mvLog_t Loglevel = MVLOG_ERROR>
+    template<mvLog_t Loglevel = MVLOG_ERROR, bool Throw = true>
     int get_configuration() {
         int configuration{};
-        call_log_throw<Loglevel>(__func__, __LINE__, libusb_get_configuration, get(), &configuration);
+        call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_get_configuration, get(), &configuration);
         return configuration;
+    }
+
+    // wrapper for libusb_set_auto_detach_kernel_driver()
+    template<mvLog_t Loglevel = MVLOG_ERROR, bool Throw = true>
+    void set_auto_detach_kernel_driver(bool enable) {
+        call_log_throw<Loglevel, Throw>(__func__, __LINE__, libusb_set_auto_detach_kernel_driver, get(), enable);
     }
 };
 

--- a/src/pc/protocols/wrap_libusb.hpp
+++ b/src/pc/protocols/wrap_libusb.hpp
@@ -1,3 +1,19 @@
+/*
+    Copyright 2023 Dale Phurrough
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
 #ifndef _WRAP_LIBUSB_HPP_
 #define _WRAP_LIBUSB_HPP_
 
@@ -28,7 +44,7 @@
 #include <vector>
 #include "wrap_libusb_details.hpp"
 
-namespace dai {
+namespace dp {
 
 ///////////////////////////////
 // Helper functions and macros
@@ -102,7 +118,7 @@ inline auto call_log_throw(const char* funcWithin, const int lineNumber, Func&& 
                   Loglevel,
                   funcWithin,
                   lineNumber,
-                  "dai::libusb failed %s(): %s",
+                  "dp::libusb failed %s(): %s",
                   funcWithin,
                   libusb_strerror(static_cast<int>(rcNum)));
         throw_conditional_usb_error(static_cast<int>(rcNum), std::integral_constant<bool, Throw>{});
@@ -261,7 +277,7 @@ public:
     using unique_resource_ptr<libusb_config_descriptor, libusb_free_config_descriptor>::unique_resource_ptr;
 
     config_descriptor(libusb_device* dev, uint8_t configIndex) noexcept(false) {
-        CALL_LOG_ERROR_THROW(libusb_get_config_descriptor, dev, configIndex, dai::out_param(*this));
+        CALL_LOG_ERROR_THROW(libusb_get_config_descriptor, dev, configIndex, out_param(*this));
     }
 };
 
@@ -295,7 +311,7 @@ public:
     using unique_resource_ptr<libusb_device_handle, libusb_close>::unique_resource_ptr;
 
     explicit device_handle(libusb_device* device) noexcept(false) {
-        CALL_LOG_ERROR_THROW(libusb_open, device, dai::out_param(*static_cast<_base*>(this)));
+        CALL_LOG_ERROR_THROW(libusb_open, device, out_param(*static_cast<_base*>(this)));
     }
 
     explicit device_handle(const usb_device& device) noexcept(false);
@@ -303,7 +319,7 @@ public:
     // wrap a platform-specific system device handle and get a libusb device_handle for it
     // never use libusb_open() on this wrapped handle's underlying device
     device_handle(libusb_context* ctx, intptr_t sysDevHandle) noexcept(false) {
-        CALL_LOG_ERROR_THROW(libusb_wrap_sys_device, ctx, sysDevHandle, dai::out_param(*static_cast<_base*>(this)));
+        CALL_LOG_ERROR_THROW(libusb_wrap_sys_device, ctx, sysDevHandle, out_param(*static_cast<_base*>(this)));
     }
 
     // copy and move constructors and assignment operators
@@ -477,7 +493,7 @@ public:
     // generate a device_handle with libusb_open() to enable i/o on the device
     device_handle open() const noexcept(false) {
         device_handle handle;
-        CALL_LOG_ERROR_THROW(libusb_open, get(), dai::out_param(handle));
+        CALL_LOG_ERROR_THROW(libusb_open, get(), out_param(handle));
         return handle;
     }
 
@@ -491,7 +507,7 @@ public:
     // wrapper for libusb_get_config_descriptor()
     config_descriptor get_config_descriptor(uint8_t configIndex) const noexcept(false) {
         config_descriptor descriptor;
-        CALL_LOG_ERROR_THROW(libusb_get_config_descriptor, get(), configIndex, dai::out_param(descriptor));
+        CALL_LOG_ERROR_THROW(libusb_get_config_descriptor, get(), configIndex, out_param(descriptor));
         return descriptor;
     }
 
@@ -536,10 +552,10 @@ template <mvLog_t Loglevel, bool Throw, unsigned int ChunkTimeoutMs, bool ZeroLe
 inline std::pair<libusb_error, ptrdiff_t> device_handle::bulk_transfer(const unsigned char endpoint,
                                                                        BufferValueType* const buffer,
                                                                        intmax_t bufferSizeBytes) const noexcept(!Throw) {
-    static constexpr auto FAIL_FORMAT =    "dai::libusb failed bulk_transfer(%u %s): %td/%jd bytes transmit; %s";
-    static constexpr auto START_FORMAT =   "dai::libusb starting bulk_transfer(%u %s): 0/%jd bytes transmit";
-    static constexpr auto ZLP_FORMAT =     "dai::libusb zerolp bulk_transfer(%u %s): %td/%jd bytes transmit";
-    static constexpr auto SUCCESS_FORMAT = "dai::libusb success bulk_transfer(%u %s): %td/%jd bytes transmit in %lf ms (%lf MB/s)";
+    static constexpr auto FAIL_FORMAT =    "dp::libusb failed bulk_transfer(%u %s): %td/%jd bytes transmit; %s";
+    static constexpr auto START_FORMAT =   "dp::libusb starting bulk_transfer(%u %s): 0/%jd bytes transmit";
+    static constexpr auto ZLP_FORMAT =     "dp::libusb zerolp bulk_transfer(%u %s): %td/%jd bytes transmit";
+    static constexpr auto SUCCESS_FORMAT = "dp::libusb success bulk_transfer(%u %s): %td/%jd bytes transmit in %lf ms (%lf MB/s)";
     static constexpr std::array<const char*, 2> DIRECTION_TEXT{"out", "in"};
     static constexpr int DEFAULT_CHUNK_SIZE = 1024 * 1024;  // must be multiple of endpoint max packet size
     static constexpr int DEFAULT_CHUNK_SIZE_USB1 = 64;      // must be multiple of endpoint max packet size
@@ -681,5 +697,5 @@ inline std::pair<libusb_error, ptrdiff_t> device_handle::bulk_transfer(const uns
 
 #undef CALL_LOG_ERROR_THROW
 
-} // namespace dai
+} // namespace dp
 #endif // _WRAP_LIBUSB_HPP_

--- a/src/pc/protocols/wrap_libusb.md
+++ b/src/pc/protocols/wrap_libusb.md
@@ -13,7 +13,7 @@ from this base resource type.
 
 `dp::libusb` is currently focused on the needs of XLink; the protocol to communicate with
 Intel Movidius/Myriad devices. A `std::shared_ptr` base for resources was considered for
-some use cases. It was not implemented due to the limited needs of XLink.
+some use cases. It is not implemented due to the limited needs of XLink; a single owner.
 
 Many raw libusb types, e.g. `libusb_device_descriptor`, are used in their simple POD form.
 Some libusb resources are not implemented, e.g. asynchronous device I/O.
@@ -34,13 +34,119 @@ Most behaviors of `dp::libusb` resources derive from `std::unique_ptr`.
    with error text sourced from `libusb_strerror()`.
 6. Raw resource pointers can be retrieved with `get()` to use with libusb C apis.
 
-## Types Overview and Hierarchy
+## Object Model and Types
 
-mermaid tbd
+All libusb wrapper classes are derived from `unique_resource_ptr<libusb_****, disposeFunc>`
+where `libusb_****` is the native libusb POD struct and `disposeFunc` is the native libusb disposing function.
+
+`unique_resource_ptr<>` is a helper class that inherits from `std::unique_ptr<libusb_****, unique_resource_deleter<libusb_****, disposeFunc>>`. It uses the normal `std::unique_ptr` custom deleter feature to automatically call `*disposeFunc(unique_ptr::get())`.
 
 * `usb_context` enhances raw `libusb_context*`
-* `device_list` container exposes iterators to raw `libusb_device*`
+* `device_list` stl container generates and grants access to all `usb_device` on the host
 * `usb_device` enhances raw `libusb_device*`
 * `device_handle` enhances raw `libusb_device_handle*`
 * `config_descriptor` enhances raw `libusb_config_descriptor*`
-* remaining libusb types are used unchanged
+* all remaining libusb classes and structs are used unchanged
+
+The typical process is
+
+1. Create a `usb_context`
+2. From that context get a `device_list`
+3. From that list choose a `usb_device`
+4. From that device get a `device_handle`
+5. Operate and transfer on that handle
+6. All resource lifetimes are RAII managed including resource release/free/exiting.
+
+### Class diagram
+
+In this diagram, the inheritance `public unique_resource_ptr<libusb_****, disposeFunc>` is abbreviated `resource<libusb_****, libusb_disposeFunction>`.
+
+```mermaid
+classDiagram
+direction TB
+
+    usb_context --> device_list
+    device_list --> usb_device
+    usb_device --> device_handle
+    usb_device --> config_descriptor
+    
+    class usb_context {
+        resource~libusb_context#44;#32;libusb_exit~
+    }
+
+    class device_list {
+        stl#32;container#32;of#32;usb_device
+        device_list(usb_context) libusb_get_device_list()
+        ~device_list() libusb_free_device_list()
+        operator[]() usb_device
+        begin() usb_device_iterator
+        size()
+        standard_container_methods_and_iterators...()
+    }
+
+    class usb_device {
+        resource~libusb_device#44;#32;libusb_unref_device~
+        usb_device(libusb_device*) libusb_ref_device(ptr)
+        open() device_handle(libusb_open(get()))
+        get_config_descriptor(configIndex)
+        get_device_descriptor()
+        get_bus_number()
+        get_port_numbers()
+    }
+
+    class device_handle {
+        resource~libusb_device_handle#44;#32;libusb_close~
+        device_handle(usb_device) libusb_open()
+        device_handle(usb_context, sysDevHandle) libusb_wrap_sys_device()
+        get_device() libusb_get_device(get())
+        claim_interface(interfaceNumber)
+        release_interface(interfaceNumber)
+        get_configuration()
+        set_configuration(configurationInt)
+        get_string_descriptor_ascii(descriptorIndex)
+        set_auto_detach_kernel_driver(bool)
+        set_max_packet_size(endpoint, size)
+        get_max_packet_size(endpoint)
+        get_device_descriptor()
+        bulk_transfer(endpoint, *buffer, bufferSize)
+        bulk_transfer(endpoint, containerBuffer)
+        bulk_transfer(endpoint, *buffer, bufferSize, *transferred, timeout)
+        control_transfer(requestType, request, value, index, *buffer, bufferSize, timeout)
+        interrupt_transfer(endpoint, *buffer, bufferSize, *transferred, timeout)
+    }
+
+    class config_descriptor {
+        resource~libusb_config_descriptor#44;#32;libusb_free_config_descriptor~
+        config_descriptor(usb_device, configIndex) libusb_get_config_descriptor()
+    }
+
+    transfer_error --|> usb_error
+    usb_error --|> system_error
+    unique_resource_ptr --|> unique_ptr
+    
+    namespace helpers {
+
+    class system_error ["std::system_error"] {
+    }
+
+    class usb_error {
+        usb_error(errorCode)
+        usb_error(errorCode, what)
+        usb_error(errorCode, what)
+    }
+
+    class transfer_error {
+        transfer_error(errorCode, transferredBytes)
+        transfer_error(errorCode, what, transferredBytes)
+        transfer_error(errorCode, what, transferredBytes)
+    }
+
+    class unique_ptr ["std::unique_ptr&lt;libusb_***, disposeFunc>"] {
+        ~unique_ptr() calls *disposeFunc(get())
+    }
+
+    class unique_resource_ptr ["unique_resource_ptr&lt;libusb_***, disposeFunc>"] {
+    }
+
+    }
+```

--- a/src/pc/protocols/wrap_libusb.md
+++ b/src/pc/protocols/wrap_libusb.md
@@ -6,15 +6,17 @@ Licensed under the Apache License, Version 2.0 http://www.apache.org/licenses/LI
 ## Overview
 
 `dp::libusb` wraps the C apis of [libusb](https://libusb.info/) with C++ unique resource classes
-that follow RAII semantics to automatically dispose resources. A simple type `dp::unique_resource_ptr`
-derives from `std::unique_ptr` and takes a C-function as a template parameter for the C api
-to dispose the resource. Most `dp::libusb` classes derive from this resource type.
-
-Many raw libusb types, e.g. `libusb_device_descriptor`, are used in their simple POD form.
-Some resources are not implemented, e.g. asynchronous device I/O.
+that follow RAII semantics for ownership and automatic disposal of resources. A simple class
+`dp::unique_resource_ptr` derives from `std::unique_ptr` with an additional template
+parameter for a C-function pointer to dispose the resource. Most `dp::libusb` classes derive
+from this base resource type.
 
 `dp::libusb` is currently focused on the needs of XLink; the protocol to communicate with
-Intel Movidius/Myriad devices.
+Intel Movidius/Myriad devices. A `std::shared_ptr` base for resources was considered for
+some use cases. It was not implemented due to the limited needs of XLink.
+
+Many raw libusb types, e.g. `libusb_device_descriptor`, are used in their simple POD form.
+Some libusb resources are not implemented, e.g. asynchronous device I/O.
 
 ## Rules
 

--- a/src/pc/protocols/wrap_libusb.md
+++ b/src/pc/protocols/wrap_libusb.md
@@ -1,0 +1,44 @@
+# `dp::libusb` - C++ wrap for libusb-1.0
+
+Copyright 2023 Dale Phurrough  
+Licensed under the Apache License, Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+
+## Overview
+
+`dp::libusb` wraps the C apis of [libusb](https://libusb.info/) with C++ unique resource classes
+that follow RAII semantics to automatically dispose resources. A simple type `dp::unique_resource_ptr`
+derives from `std::unique_ptr` and takes a C-function as a template parameter for the C api
+to dispose the resource. Most `dp::libusb` classes derive from this resource type.
+
+Many raw libusb types, e.g. `libusb_device_descriptor`, are used in their simple POD form.
+Some resources are not implemented, e.g. asynchronous device I/O.
+
+`dp::libusb` is currently focused on the needs of XLink; the protocol to communicate with
+Intel Movidius/Myriad devices.
+
+## Rules
+
+Most behaviors of `dp::libusb` resources derive from `std::unique_ptr`.
+
+1. `dp::libusb` resources permit empty/nullptr contents.
+   `dp::libusb::device_handle handle{nullptr};` and `handle.reset()` are both valid code.
+2. Behavior is undefined when code uses or operates on an empty resource.
+   `handle.claim_interface(1);` and `*handle` would both likely crash your application.
+3. Behavior is undefined when code transforms an empty resource.
+   `libusb_device* device = nullptr; dp::libusb::device_handle handle{device};` will likely crash your application.
+4. `dp::libusb::device_list` follows the behaviors and apis of STL containers. It can
+   be used in places an STL container can be used.
+5. Raw libusb return codes for failures are transformed into `dp::libusb::usb_error` exceptions
+   with error text sourced from `libusb_strerror()`.
+6. Raw resource pointers can be retrieved with `get()` to use with libusb C apis.
+
+## Types Overview and Hierarchy
+
+mermaid tbd
+
+* `usb_context` enhances raw `libusb_context*`
+* `device_list` container exposes iterators to raw `libusb_device*`
+* `usb_device` enhances raw `libusb_device*`
+* `device_handle` enhances raw `libusb_device_handle*`
+* `config_descriptor` enhances raw `libusb_config_descriptor*`
+* remaining libusb types are used unchanged

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -1,4 +1,6 @@
 /*
+    dp::libusb - C++ wrapper for libusb-1.0 (focused on use with the XLink protocol)
+
     Copyright 2023 Dale Phurrough
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -66,24 +66,24 @@ struct out_param_t {
     pointer pRaw;
     bool replace = true;
 
-    out_param_t(T& output) : wrapper(output), pRaw(nullptr) {}
+    explicit out_param_t(T& output) noexcept : wrapper(output), pRaw(nullptr) {}
 
-    out_param_t(out_param_t&& other) noexcept : wrapper(other.wrapper), pRaw(other.pRaw) {
+    out_param_t(out_param_t&& other) noexcept(noexcept(std::declval<T>().reset(std::declval<pointer>()))) : wrapper(other.wrapper), pRaw(other.pRaw) {
         assert(other.replace);
         other.replace = false;
     }
 
-    operator pointer*() {
+    operator pointer*() noexcept {
         assert(replace);
         return &pRaw;
     }
 
-    operator pointer&() {
+    operator pointer&() noexcept {
         assert(replace);
         return pRaw;
     }
 
-    ~out_param_t() {
+    ~out_param_t() noexcept(noexcept(std::declval<T>().reset(std::declval<pointer>()))) {
         if(replace) {
             wrapper.reset(pRaw);
         }
@@ -100,19 +100,19 @@ struct out_param_ptr_t {
     pointer pRaw;
     bool replace = true;
 
-    out_param_ptr_t(T& output) : wrapper(output), pRaw(nullptr) {}
+    explicit out_param_ptr_t(T& output) noexcept : wrapper(output), pRaw(nullptr) {}
 
-    out_param_ptr_t(out_param_ptr_t&& other) noexcept : wrapper(other.wrapper), pRaw(other.pRaw) {
+    out_param_ptr_t(out_param_ptr_t&& other) noexcept(noexcept(std::declval<T>().reset(std::declval<pointer>()))) : wrapper(other.wrapper), pRaw(other.pRaw) {
         assert(other.replace);
         other.replace = false;
     }
 
-    operator Tcast() {
+    operator Tcast() noexcept {
         assert(replace);
         return reinterpret_cast<Tcast>(&pRaw);
     }
 
-    ~out_param_ptr_t() {
+    ~out_param_ptr_t() noexcept(noexcept(std::declval<T>().reset(std::declval<pointer>()))) {
         if(replace) {
             wrapper.reset(pRaw);
         }
@@ -128,7 +128,7 @@ struct out_param_ptr_t {
 This avoids multi-step handling of a raw resource to establish the smart pointer.
 Example: `GetFoo(out_param(foo));` */
 template <typename T>
-details::out_param_t<T> out_param(T& p) {
+details::out_param_t<T> out_param(T& p) noexcept(noexcept(details::out_param_t<T>(p))) {
     return details::out_param_t<T>(p);
 }
 
@@ -136,7 +136,7 @@ details::out_param_t<T> out_param(T& p) {
 Use only when the smart pointer's &handle is not equal to the output type a function requires, necessitating a cast.
 Example: `dp::out_param_ptr<PSECURITY_DESCRIPTOR*>(securityDescriptor)` */
 template <typename Tcast, typename T>
-details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p) {
+details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p) noexcept(noexcept(details::out_param_ptr_t<Tcast, T>(p))) {
     return details::out_param_ptr_t<Tcast, T>(p);
 }
 

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -35,14 +35,20 @@ namespace details {
 // checks for C++14, when not available then include definitions
 #if WRAP_CPLUSPLUS < 201402L
 // implements std::exchange for compilers older than C++14
-template <class _Ty, class _Other = _Ty>
-_Ty exchange(_Ty& _Val, _Other&& _New_val) noexcept(std::is_nothrow_move_constructible<_Ty>::value&& std::is_nothrow_assignable<_Ty&, _Other>::value) {
-    _Ty _Old_val = static_cast<_Ty&&>(_Val);
-    _Val = static_cast<_Other&&>(_New_val);
-    return _Old_val;
+template <class T, class Other = T>
+T exchange(T& val, Other&& newVal) noexcept(std::is_nothrow_move_constructible<T>::value&& std::is_nothrow_assignable<T&, Other>::value) {
+    T oldVal = static_cast<T&&>(val);
+    val = static_cast<Other&&>(newVal);
+    return oldVal;
+}
+template <typename T>
+constexpr const T& min(const T& left, const T& right) noexcept(noexcept(right < left)) {
+    return right < left ? right : left;
 }
 #else
 using std::exchange;
+#include <algorithm>
+using std::min;
 #endif
 
 //! Type traits class that identifies the inner type of any smart pointer.

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -32,24 +32,6 @@ namespace dai {
 // https://github.com/microsoft/wil/wiki/RAII-resource-wrappers#wilout_param
 
 namespace details {
-// checks for C++14, when not available then include definitions
-#if WRAP_CPLUSPLUS < 201402L
-// implements std::exchange for compilers older than C++14
-template <class T, class Other = T>
-T exchange(T& val, Other&& newVal) noexcept(std::is_nothrow_move_constructible<T>::value&& std::is_nothrow_assignable<T&, Other>::value) {
-    T oldVal = static_cast<T&&>(val);
-    val = static_cast<Other&&>(newVal);
-    return oldVal;
-}
-template <typename T>
-constexpr const T& min(const T& left, const T& right) noexcept(noexcept(right < left)) {
-    return right < left ? right : left;
-}
-#else
-using std::exchange;
-#include <algorithm>
-using std::min;
-#endif
 
 //! Type traits class that identifies the inner type of any smart pointer.
 template <typename Ptr>
@@ -148,11 +130,11 @@ class span {
         size_ = other.size_;
         return *this;
     }
-    span(span&& other) noexcept : ptr_{details::exchange(other.ptr_, nullptr)}, size_{details::exchange(other.size_, 0)} {};
+    span(span&& other) noexcept : ptr_{std::exchange(other.ptr_, nullptr)}, size_{std::exchange(other.size_, 0)} {};
     span& operator=(span&& other) noexcept {
         if(this == &other) return *this;
-        ptr_ = details::exchange(other.ptr_, nullptr);
-        size_ = details::exchange(other.size_, 0);
+        ptr_ = std::exchange(other.ptr_, nullptr);
+        size_ = std::exchange(other.size_, 0);
         return *this;
     }
 

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -12,158 +12,284 @@
 #ifndef _WRAP_LIBUSB_DETAILS_HPP_
 #define _WRAP_LIBUSB_DETAILS_HPP_
 
-
 // _MSVC_LANG is the more accurate way to get the C++ version in MSVC
 #if defined(_MSVC_LANG) && (_MSVC_LANG > __cplusplus)
-#define WRAP_CPLUSPLUS _MSVC_LANG
+    #define WRAP_CPLUSPLUS _MSVC_LANG
 #else
-#define WRAP_CPLUSPLUS __cplusplus
+    #define WRAP_CPLUSPLUS __cplusplus
 #endif
 
-#if WRAP_CPLUSPLUS >= 201703L
-    #define WRAP_NODISCARD [[nodiscard]]
-#else
-    #define WRAP_NODISCARD
-#endif
-
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
 namespace dai {
-    // subset of WIL that defines out parameters for smart pointers
-    // https://github.com/microsoft/wil/wiki/RAII-resource-wrappers#wilout_param
+// subset of WIL that defines out parameters for smart pointers
+// https://github.com/microsoft/wil/wiki/RAII-resource-wrappers#wilout_param
 
-    namespace details
-    {
-        // checks for C++14, when not available then include definitions
-        #if WRAP_CPLUSPLUS >= 201402L
-            using std::exchange;
-        #else
-            // implements std::exchange for compilers older than C++14
-            template <class _Ty, class _Other = _Ty>
-            _Ty exchange(_Ty& _Val, _Other&& _New_val) noexcept(
-                std::is_nothrow_move_constructible<_Ty>::value && std::is_nothrow_assignable<_Ty&, _Other>::value) {
-                _Ty _Old_val = static_cast<_Ty&&>(_Val);
-                _Val         = static_cast<_Other&&>(_New_val);
-                return _Old_val;
-            }
-        #endif
+namespace details {
+// checks for C++14, when not available then include definitions
+#if WRAP_CPLUSPLUS < 201402L
+// implements std::exchange for compilers older than C++14
+template <class _Ty, class _Other = _Ty>
+_Ty exchange(_Ty& _Val, _Other&& _New_val) noexcept(std::is_nothrow_move_constructible<_Ty>::value&& std::is_nothrow_assignable<_Ty&, _Other>::value) {
+    _Ty _Old_val = static_cast<_Ty&&>(_Val);
+    _Val = static_cast<_Other&&>(_New_val);
+    return _Old_val;
+}
+#else
+using std::exchange;
+#endif
 
-        //! Type traits class that identifies the inner type of any smart pointer.
-        template <typename Ptr>
-        struct smart_pointer_details
-        {
-            typedef typename Ptr::pointer pointer;
-        };
+//! Type traits class that identifies the inner type of any smart pointer.
+template <typename Ptr>
+struct smart_pointer_details {
+    typedef typename Ptr::pointer pointer;
+};
 
-        template <typename T>
-        struct out_param_t
-        {
-            typedef typename smart_pointer_details<T>::pointer pointer;
-            T &wrapper;
-            pointer pRaw;
-            bool replace = true;
+template <typename T>
+struct out_param_t {
+    typedef typename smart_pointer_details<T>::pointer pointer;
+    T& wrapper;
+    pointer pRaw;
+    bool replace = true;
 
-            out_param_t(T &output) :
-                wrapper(output),
-                pRaw(nullptr)
-            {
-            }
+    out_param_t(T& output) : wrapper(output), pRaw(nullptr) {}
 
-            out_param_t(out_param_t&& other) noexcept :
-                wrapper(other.wrapper),
-                pRaw(other.pRaw)
-            {
-                assert(other.replace);
-                other.replace = false;
-            }
-
-            operator pointer*()
-            {
-                assert(replace);
-                return &pRaw;
-            }
-
-            operator pointer&()
-            {
-                assert(replace);
-                return pRaw;
-            }
-
-            ~out_param_t()
-            {
-                if (replace)
-                {
-                    wrapper.reset(pRaw);
-                }
-            }
-
-            out_param_t(out_param_t const &other) = delete;
-            out_param_t &operator=(out_param_t const &other) = delete;
-        };
-
-        template <typename Tcast, typename T>
-        struct out_param_ptr_t
-        {
-            typedef typename smart_pointer_details<T>::pointer pointer;
-            T &wrapper;
-            pointer pRaw;
-            bool replace = true;
-
-            out_param_ptr_t(T &output) :
-                wrapper(output),
-                pRaw(nullptr)
-            {
-            }
-
-            out_param_ptr_t(out_param_ptr_t&& other) noexcept :
-                wrapper(other.wrapper),
-                pRaw(other.pRaw)
-            {
-                assert(other.replace);
-                other.replace = false;
-            }
-
-            operator Tcast()
-            {
-                assert(replace);
-                return reinterpret_cast<Tcast>(&pRaw);
-            }
-
-            ~out_param_ptr_t()
-            {
-                if (replace)
-                {
-                    wrapper.reset(pRaw);
-                }
-            }
-
-            out_param_ptr_t(out_param_ptr_t const &other) = delete;
-            out_param_ptr_t &operator=(out_param_ptr_t const &other) = delete;
-        };
-    } // details
-
-      /** Use to retrieve raw out parameter pointers into smart pointers that do not support the '&' operator.
-      This avoids multi-step handling of a raw resource to establish the smart pointer.
-      Example: `GetFoo(out_param(foo));` */
-    template <typename T>
-    details::out_param_t<T> out_param(T& p)
-    {
-        return details::out_param_t<T>(p);
+    out_param_t(out_param_t&& other) noexcept : wrapper(other.wrapper), pRaw(other.pRaw) {
+        assert(other.replace);
+        other.replace = false;
     }
 
-    /** Use to retrieve raw out parameter pointers (with a required cast) into smart pointers that do not support the '&' operator.
-    Use only when the smart pointer's &handle is not equal to the output type a function requires, necessitating a cast.
-    Example: `dai::out_param_ptr<PSECURITY_DESCRIPTOR*>(securityDescriptor)` */
-    template <typename Tcast, typename T>
-    details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p)
-    {
-        return details::out_param_ptr_t<Tcast, T>(p);
+    operator pointer*() {
+        assert(replace);
+        return &pRaw;
     }
 
+    operator pointer&() {
+        assert(replace);
+        return pRaw;
+    }
+
+    ~out_param_t() {
+        if(replace) {
+            wrapper.reset(pRaw);
+        }
+    }
+
+    out_param_t(out_param_t const& other) = delete;
+    out_param_t& operator=(out_param_t const& other) = delete;
+};
+
+template <typename Tcast, typename T>
+struct out_param_ptr_t {
+    typedef typename smart_pointer_details<T>::pointer pointer;
+    T& wrapper;
+    pointer pRaw;
+    bool replace = true;
+
+    out_param_ptr_t(T& output) : wrapper(output), pRaw(nullptr) {}
+
+    out_param_ptr_t(out_param_ptr_t&& other) noexcept : wrapper(other.wrapper), pRaw(other.pRaw) {
+        assert(other.replace);
+        other.replace = false;
+    }
+
+    operator Tcast() {
+        assert(replace);
+        return reinterpret_cast<Tcast>(&pRaw);
+    }
+
+    ~out_param_ptr_t() {
+        if(replace) {
+            wrapper.reset(pRaw);
+        }
+    }
+
+    out_param_ptr_t(out_param_ptr_t const& other) = delete;
+    out_param_ptr_t& operator=(out_param_ptr_t const& other) = delete;
+};
+
+#if WRAP_CPLUSPLUS < 202002L
+// simple implementation of std::span for compilers older than C++20
+// includes non-standard bounds checking
+template <typename T>
+class span {
+   public:
+    using element_type = T;
+    using value_type = typename std::remove_cv<T>::type;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    span() noexcept = default;
+    ~span() noexcept = default;
+    span(const span& other) noexcept : ptr_(other.data()), size_(other.size()) {}
+    span& operator=(const span& other) noexcept {
+        if(this == &other) return *this;
+        ptr_ = other.ptr_;
+        size_ = other.size_;
+        return *this;
+    }
+    span(span&& other) noexcept : ptr_{details::exchange(other.ptr_, nullptr)}, size_{details::exchange(other.size_, 0)} {};
+    span& operator=(span&& other) noexcept {
+        if(this == &other) return *this;
+        ptr_ = details::exchange(other.ptr_, nullptr);
+        size_ = details::exchange(other.size_, 0);
+        return *this;
+    }
+
+    span(T* ptr, std::size_t size) noexcept : ptr_(ptr), size_(size) {}
+
+    template <std::size_t N>
+    span(std::array<T, N>& arr) noexcept : ptr_(arr.data()), size_(N) {}
+
+    template <std::size_t N>
+    span(const std::array<T, N>& arr) noexcept : ptr_(arr.data()), size_(N) {}
+
+    template <typename Iterator>
+    span(Iterator begin, Iterator end) noexcept : ptr_(&(*begin)), size_(std::distance(begin, end)) {}
+
+    pointer data() noexcept {
+        return ptr_;
+    }
+    const_pointer data() const noexcept {
+        return ptr_;
+    }
+    size_type size() const noexcept {
+        return size_;
+    }
+    size_type size_bytes() const noexcept {
+        return size_ * sizeof(T);
+    }
+
+    // includes non-standard bounds checking
+    reference operator[](size_type index) const {
+        if(index >= size_) {
+            throw std::out_of_range(throwText);
+        }
+        return ptr_[index];
+    }
+
+    iterator begin() noexcept {
+        return ptr_;
+    }
+    const_iterator begin() const noexcept {
+        return ptr_;
+    }
+    iterator end() noexcept {
+        return ptr_ + size_;
+    }
+    const_iterator end() const noexcept {
+        return ptr_ + size_;
+    }
+    const_iterator cbegin() const noexcept {
+        return ptr_;
+    }
+    const_iterator cend() const noexcept {
+        return ptr_ + size_;
+    }
+
+    reverse_iterator rbegin() noexcept {
+        return reverse_iterator(end());
+    }
+    const_reverse_iterator rbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+    reverse_iterator rend() noexcept {
+        return reverse_iterator(begin());
+    }
+    const_reverse_iterator rend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+    const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(cend());
+    }
+    const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(cbegin());
+    }
+
+    bool empty() const noexcept {
+        return size_ == 0;
+    }
+
+    // includes non-standard bounds checking
+    reference front() const {
+        if(size_ == 0) {
+            throw std::out_of_range(throwText);
+        }
+        return ptr_[0];
+    }
+
+    // includes non-standard bounds checking
+    reference back() const {
+        if(size_ == 0) {
+            throw std::out_of_range(throwText);
+        }
+        return ptr_[size_ - 1];
+    }
+
+    // includes non-standard bounds checking
+    span<T> subspan(size_type offset, size_type count = size_type(-1)) const {
+        if(offset > size_) {
+            throw std::out_of_range(throwText);
+        }
+        if(count == size_type(-1)) {
+            count = size_ - offset;
+        }
+        if(offset + count > size_) {
+            throw std::out_of_range(throwText);
+        }
+        return span<T>(ptr_ + offset, count);
+    }
+
+    span<const unsigned char> as_bytes() const noexcept {
+        return {reinterpret_cast<const unsigned char*>(ptr_), size_ * sizeof(T)};
+    }
+
+    span<unsigned char> as_writable_bytes() const noexcept {
+        return {reinterpret_cast<unsigned char*>(ptr_), size_ * sizeof(T)};
+    }
+
+   private:
+    element_type* ptr_ = nullptr;
+    size_type size_ = 0;
+    const char* const throwText = "span index out of range";
+};
+#else
+#include <span>
+using std::span;
+#endif
+
+}  // namespace details
+
+/** Use to retrieve raw out parameter pointers into smart pointers that do not support the '&' operator.
+This avoids multi-step handling of a raw resource to establish the smart pointer.
+Example: `GetFoo(out_param(foo));` */
+template <typename T>
+details::out_param_t<T> out_param(T& p) {
+    return details::out_param_t<T>(p);
 }
 
+/** Use to retrieve raw out parameter pointers (with a required cast) into smart pointers that do not support the '&' operator.
+Use only when the smart pointer's &handle is not equal to the output type a function requires, necessitating a cast.
+Example: `dai::out_param_ptr<PSECURITY_DESCRIPTOR*>(securityDescriptor)` */
+template <typename Tcast, typename T>
+details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p) {
+    return details::out_param_ptr_t<Tcast, T>(p);
+}
+}  // namespace dai
+
 #undef WRAP_CPLUSPLUS
-#undef WRAP_NODISCARD
-#endif // _WRAP_LIBUSB_DETAILS_HPP_
+#endif  // _WRAP_LIBUSB_DETAILS_HPP_

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -1,0 +1,150 @@
+//*********************************************************
+//    Portions of this code are from the Microsoft WIL project.
+//    Copyright (c) Microsoft. All rights reserved.
+//    This code is licensed under the MIT License.
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+//    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+//    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//    PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//
+//*********************************************************
+
+#ifndef _WRAP_LIBUSB_DETAILS_HPP_
+#define _WRAP_LIBUSB_DETAILS_HPP_
+
+
+// _MSVC_LANG is the more accurate way to get the C++ version in MSVC
+#if defined(_MSVC_LANG) && (_MSVC_LANG > __cplusplus)
+#define __WRAP_CPLUSPLUS _MSVC_LANG
+#else
+#define __WRAP_CPLUSPLUS __cplusplus
+#endif
+
+#if __WRAP_CPLUSPLUS >= 201703L
+    #define XLINK_NODISCARD [[nodiscard]]
+#else
+    #define XLINK_NODISCARD
+#endif
+
+#include <cassert>
+
+namespace dai {
+    // subset of WIL that defines out parameters for smart pointers
+    // https://github.com/microsoft/wil/wiki/RAII-resource-wrappers#wilout_param
+
+    //! Type traits class that identifies the inner type of any smart pointer.
+    template <typename Ptr>
+    struct smart_pointer_details
+    {
+        typedef typename Ptr::pointer pointer;
+    };
+
+    namespace details
+    {
+        template <typename T>
+        struct out_param_t
+        {
+            typedef typename dai::smart_pointer_details<T>::pointer pointer;
+            T &wrapper;
+            pointer pRaw;
+            bool replace = true;
+
+            out_param_t(T &output) :
+                wrapper(output),
+                pRaw(nullptr)
+            {
+            }
+
+            out_param_t(out_param_t&& other) noexcept :
+                wrapper(other.wrapper),
+                pRaw(other.pRaw)
+            {
+                assert(other.replace);
+                other.replace = false;
+            }
+
+            operator pointer*()
+            {
+                assert(replace);
+                return &pRaw;
+            }
+
+            operator pointer&()
+            {
+                assert(replace);
+                return pRaw;
+            }
+
+            ~out_param_t()
+            {
+                if (replace)
+                {
+                    wrapper.reset(pRaw);
+                }
+            }
+
+            out_param_t(out_param_t const &other) = delete;
+            out_param_t &operator=(out_param_t const &other) = delete;
+        };
+
+        template <typename Tcast, typename T>
+        struct out_param_ptr_t
+        {
+            typedef typename dai::smart_pointer_details<T>::pointer pointer;
+            T &wrapper;
+            pointer pRaw;
+            bool replace = true;
+
+            out_param_ptr_t(T &output) :
+                wrapper(output),
+                pRaw(nullptr)
+            {
+            }
+
+            out_param_ptr_t(out_param_ptr_t&& other) noexcept :
+                wrapper(other.wrapper),
+                pRaw(other.pRaw)
+            {
+                assert(other.replace);
+                other.replace = false;
+            }
+
+            operator Tcast()
+            {
+                assert(replace);
+                return reinterpret_cast<Tcast>(&pRaw);
+            }
+
+            ~out_param_ptr_t()
+            {
+                if (replace)
+                {
+                    wrapper.reset(pRaw);
+                }
+            }
+
+            out_param_ptr_t(out_param_ptr_t const &other) = delete;
+            out_param_ptr_t &operator=(out_param_ptr_t const &other) = delete;
+        };
+    } // details
+
+      /** Use to retrieve raw out parameter pointers into smart pointers that do not support the '&' operator.
+      This avoids multi-step handling of a raw resource to establish the smart pointer.
+      Example: `GetFoo(out_param(foo));` */
+    template <typename T>
+    details::out_param_t<T> out_param(T& p)
+    {
+        return details::out_param_t<T>(p);
+    }
+
+    /** Use to retrieve raw out parameter pointers (with a required cast) into smart pointers that do not support the '&' operator.
+    Use only when the smart pointer's &handle is not equal to the output type a function requires, necessitating a cast.
+    Example: `dai::out_param_ptr<PSECURITY_DESCRIPTOR*>(securityDescriptor)` */
+    template <typename Tcast, typename T>
+    details::out_param_ptr_t<Tcast, T> out_param_ptr(T& p)
+    {
+        return details::out_param_ptr_t<Tcast, T>(p);
+    }
+
+}
+#endif // _WRAP_LIBUSB_DETAILS_HPP_

--- a/src/pc/protocols/wrap_libusb_details.hpp
+++ b/src/pc/protocols/wrap_libusb_details.hpp
@@ -15,15 +15,15 @@
 
 // _MSVC_LANG is the more accurate way to get the C++ version in MSVC
 #if defined(_MSVC_LANG) && (_MSVC_LANG > __cplusplus)
-#define __WRAP_CPLUSPLUS _MSVC_LANG
+#define WRAP_CPLUSPLUS _MSVC_LANG
 #else
-#define __WRAP_CPLUSPLUS __cplusplus
+#define WRAP_CPLUSPLUS __cplusplus
 #endif
 
-#if __WRAP_CPLUSPLUS >= 201703L
-    #define XLINK_NODISCARD [[nodiscard]]
+#if WRAP_CPLUSPLUS >= 201703L
+    #define WRAP_NODISCARD [[nodiscard]]
 #else
-    #define XLINK_NODISCARD
+    #define WRAP_NODISCARD
 #endif
 
 #include <cassert>
@@ -147,4 +147,6 @@ namespace dai {
     }
 
 }
+
+#undef WRAP_NODISCARD
 #endif // _WRAP_LIBUSB_DETAILS_HPP_

--- a/src/shared/XLinkData.c
+++ b/src/shared/XLinkData.c
@@ -49,7 +49,7 @@ streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size)
     XLINK_RET_ERR_IF(stream_write_size < 0, INVALID_STREAM_ID);
 
     xLinkDesc_t* link = getLinkById(id);
-    mvLog(MVLOG_DEBUG,"%s() id %d link %p\n", __func__, id, link);
+    mvLog(MVLOG_DEBUG,"%s() id %d link %p", __func__, id, link);
     XLINK_RET_ERR_IF(link == NULL, INVALID_STREAM_ID);
     XLINK_RET_ERR_IF(getXLinkState(link) != XLINK_UP, INVALID_STREAM_ID);
     XLINK_RET_ERR_IF(strlen(name) >= MAX_STREAM_NAME_LENGTH, INVALID_STREAM_ID);
@@ -189,7 +189,7 @@ XLinkError_t XLinkWriteDataWithTimeout(streamId_t const streamId, const uint8_t*
     XLINK_INIT_EVENT(event, streamIdOnly, XLINK_WRITE_REQ,
         size,(void*)buffer, link->deviceHandle);
 
-    mvLog(MVLOG_WARN,"XLinkWriteDataWithTimeout is not fully supported yet. The XLinkWriteData method is called instead. Desired timeout = %d\n", timeoutMs);
+    mvLog(MVLOG_WARN,"XLinkWriteDataWithTimeout is not fully supported yet. The XLinkWriteData method is called instead. Desired timeout = %d", timeoutMs);
     XLINK_RET_IF_FAIL(addEventWithPerf(&event, &opTime, timeoutMs));
 
     if( glHandler->profEnable) {
@@ -423,7 +423,7 @@ XLinkError_t addEvent(xLinkEvent_t *event, unsigned int timeoutMs)
 
     xLinkEvent_t* ev = DispatcherAddEvent(EVENT_LOCAL, event);
     if(ev == NULL) {
-        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s\n",
+        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s",
             TypeToStr(event->header.type), event->header.id, event->header.streamName);
         return X_LINK_ERROR;
     }
@@ -488,7 +488,7 @@ XLinkError_t addEventTimeout(xLinkEvent_t *event, struct timespec abstime)
 
     xLinkEvent_t* ev = DispatcherAddEvent(EVENT_LOCAL, event);
     if(ev == NULL) {
-        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s\n",
+        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s",
             TypeToStr(event->header.type), event->header.id, event->header.streamName);
         return X_LINK_ERROR;
     }

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -90,7 +90,7 @@ XLinkError_t XLinkInitialize(XLinkGlobalHandler_t* globalHandler)
     ASSERT_XLINK(XLINK_MAX_STREAMS <= MAX_POOLS_ALLOC);
     glHandler = globalHandler;
     if (sem_init(&pingSem,0,0)) {
-        mvLog(MVLOG_ERROR, "Can't create semaphore\n");
+        mvLog(MVLOG_ERROR, "Can't create semaphore");
     }
     int i;
 
@@ -235,7 +235,7 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
 
     xLinkDesc_t* link = getNextAvailableLink();
     XLINK_RET_IF(link == NULL);
-    mvLog(MVLOG_DEBUG,"%s() device name %s glHandler %p protocol %d\n", __func__, handler->devicePath, glHandler, handler->protocol);
+    mvLog(MVLOG_DEBUG,"%s() device name %s glHandler %p protocol %d", __func__, handler->devicePath, glHandler, handler->protocol);
 
     link->deviceHandle.protocol = handler->protocol;
     int connectStatus = XLinkPlatformConnect(handler->devicePath2, handler->devicePath,
@@ -330,7 +330,7 @@ XLinkError_t XLinkResetRemote(linkId_t id)
     xLinkEvent_t event = {0};
     event.header.type = XLINK_RESET_REQ;
     event.deviceHandle = link->deviceHandle;
-    mvLog(MVLOG_DEBUG, "sending reset remote event\n");
+    mvLog(MVLOG_DEBUG, "sending reset remote event");
     DispatcherAddEvent(EVENT_LOCAL, &event);
     XLINK_RET_ERR_IF(DispatcherWaitEventComplete(&link->deviceHandle, XLINK_NO_RW_TIMEOUT),
         X_LINK_TIMEOUT);
@@ -339,7 +339,7 @@ XLinkError_t XLinkResetRemote(linkId_t id)
     while(((rc = XLink_sem_wait(&link->dispatcherClosedSem)) == -1) && errno == EINTR)
         continue;
     if(rc) {
-        mvLog(MVLOG_ERROR,"can't wait dispatcherClosedSem\n");
+        mvLog(MVLOG_ERROR,"can't wait dispatcherClosedSem");
         return X_LINK_ERROR;
     }
 
@@ -361,7 +361,7 @@ XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs)
     xLinkEvent_t event = {0};
     event.header.type = XLINK_RESET_REQ;
     event.deviceHandle = link->deviceHandle;
-    mvLog(MVLOG_DEBUG, "sending reset remote event\n");
+    mvLog(MVLOG_DEBUG, "sending reset remote event");
 
     struct timespec start;
     clock_gettime(CLOCK_REALTIME, &start);
@@ -376,7 +376,7 @@ XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs)
 
     xLinkEvent_t* ev = DispatcherAddEvent(EVENT_LOCAL, &event);
     if(ev == NULL) {
-        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s\n",
+        mvLog(MVLOG_ERROR, "Dispatcher failed on adding event. type: %s, id: %d, stream name: %s",
             TypeToStr(event.header.type), event.header.id, event.header.streamName);
         return X_LINK_ERROR;
     }
@@ -391,7 +391,7 @@ XLinkError_t XLinkResetRemoteTimeout(linkId_t id, int timeoutMs)
 
     // Wait for dispatcher to be closed
     if(XLink_sem_wait(&link->dispatcherClosedSem)) {
-        mvLog(MVLOG_ERROR,"can't wait dispatcherClosedSem\n");
+        mvLog(MVLOG_ERROR,"can't wait dispatcherClosedSem");
         return X_LINK_ERROR;
     }
 
@@ -412,7 +412,7 @@ XLinkError_t XLinkResetAll()
             for (stream = 0; stream < XLINK_MAX_STREAMS; stream++) {
                 if (link->availableStreams[stream].id != INVALID_STREAM_ID) {
                     streamId_t streamId = link->availableStreams[stream].id;
-                    mvLog(MVLOG_DEBUG,"%s() Closing stream (stream = %d) %d on link %d\n",
+                    mvLog(MVLOG_DEBUG,"%s() Closing stream (stream = %d) %d on link %d",
                           __func__, stream, (int) streamId, (int) link->id);
                     COMBINE_IDS(streamId, link->id);
                     if (XLinkCloseStream(streamId) != X_LINK_SUCCESS) {
@@ -543,7 +543,7 @@ static linkId_t getNextAvailableLinkUniqueId()
             nextUniqueLinkId = 0;
         }
     } while (start != nextUniqueLinkId);
-    mvLog(MVLOG_ERROR, "%s():- no next available unique link id!\n", __func__);
+    mvLog(MVLOG_ERROR, "%s():- no next available unique link id!", __func__);
     return INVALID_LINK_ID;
 }
 
@@ -565,7 +565,7 @@ static xLinkDesc_t* getNextAvailableLink() {
     }
 
     if(i >= MAX_LINKS) {
-        mvLog(MVLOG_ERROR,"%s():- no next available link!\n", __func__);
+        mvLog(MVLOG_ERROR,"%s():- no next available link!", __func__);
         XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
         return NULL;
     }
@@ -573,7 +573,7 @@ static xLinkDesc_t* getNextAvailableLink() {
     xLinkDesc_t* link = &availableXLinks[i];
 
     if (XLink_sem_init(&link->dispatcherClosedSem, 0 ,0)) {
-        mvLog(MVLOG_ERROR, "Cannot initialize semaphore\n");
+        mvLog(MVLOG_ERROR, "Cannot initialize semaphore");
         XLINK_RET_ERR_IF(pthread_mutex_unlock(&availableXLinksMutex) != 0, NULL);
         return NULL;
     }
@@ -587,13 +587,13 @@ static xLinkDesc_t* getNextAvailableLink() {
 static void freeGivenLink(xLinkDesc_t* link) {
 
     if(pthread_mutex_lock(&availableXLinksMutex) != 0){
-        mvLog(MVLOG_ERROR, "Cannot lock mutex\n");
+        mvLog(MVLOG_ERROR, "Cannot lock mutex");
         return;
     }
 
     link->id = INVALID_LINK_ID;
     if (XLink_sem_destroy(&link->dispatcherClosedSem)) {
-        mvLog(MVLOG_ERROR, "Cannot destroy semaphore\n");
+        mvLog(MVLOG_ERROR, "Cannot destroy semaphore");
     }
 
     pthread_mutex_unlock(&availableXLinksMutex);

--- a/src/shared/XLinkDispatcherImpl.c
+++ b/src/shared/XLinkDispatcherImpl.c
@@ -46,14 +46,14 @@ static int handleIncomingEvent(xLinkEvent_t* event);
 //adds a new event with parameters and returns event id
 int dispatcherEventSend(xLinkEvent_t *event)
 {
-    mvLog(MVLOG_DEBUG, "Send event: %s, size %d, streamId %ld.\n",
+    mvLog(MVLOG_DEBUG, "Send event: %s, size %d, streamId %ld.",
         TypeToStr(event->header.type), event->header.size, event->header.streamId);
 
     int rc = XLinkPlatformWrite(&event->deviceHandle,
         &event->header, sizeof(event->header));
 
     if(rc < 0) {
-        mvLog(MVLOG_ERROR,"Write failed (header) (err %d) | event %s\n", rc, TypeToStr(event->header.type));
+        mvLog(MVLOG_ERROR,"Write failed (header) (err %d) | event %s", rc, TypeToStr(event->header.type));
         return rc;
     }
 
@@ -61,7 +61,7 @@ int dispatcherEventSend(xLinkEvent_t *event)
         rc = XLinkPlatformWrite(&event->deviceHandle,
             event->data, event->header.size);
         if(rc < 0) {
-            mvLog(MVLOG_ERROR,"Write failed %d\n", rc);
+            mvLog(MVLOG_ERROR,"Write failed %d", rc);
             return rc;
         }
     }
@@ -74,7 +74,7 @@ int dispatcherEventReceive(xLinkEvent_t* event){
     int rc = XLinkPlatformRead(&event->deviceHandle,
         &event->header, sizeof(event->header));
 
-    // mvLog(MVLOG_DEBUG,"Incoming event %p: %s %d %p prevEvent: %s %d %p\n",
+    // mvLog(MVLOG_DEBUG,"Incoming event %p: %s %d %p prevEvent: %s %d %p",
     //       event,
     //       TypeToStr(event->header.type),
     //       (int)event->header.id,
@@ -84,7 +84,7 @@ int dispatcherEventReceive(xLinkEvent_t* event){
     //       prevEvent.deviceHandle.xLinkFD);
 
     if(rc < 0) {
-        mvLog(MVLOG_WARN,"%s() Read failed %d\n", __func__, (int)rc);
+        mvLog(MVLOG_WARN,"%s() Read failed %d", __func__, (int)rc);
         return rc;
     }
 
@@ -92,7 +92,7 @@ int dispatcherEventReceive(xLinkEvent_t* event){
     // if (prevEvent.header.id == event->header.id &&
     //     prevEvent.header.type == event->header.type &&
     //     prevEvent.deviceHandle.xLinkFD == event->deviceHandle.xLinkFD) {
-    //     mvLog(MVLOG_FATAL,"Duplicate id detected. \n");
+    //     mvLog(MVLOG_FATAL,"Duplicate id detected.");
     // }
     // prevEvent = *event;
 
@@ -104,7 +104,7 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
 {
     streamDesc_t* stream;
     response->header.id = event->header.id;
-    mvLog(MVLOG_DEBUG, "%s\n",TypeToStr(event->header.type));
+    mvLog(MVLOG_DEBUG, "%s",TypeToStr(event->header.type));
     switch (event->header.type){
         case XLINK_WRITE_REQ:
         {
@@ -112,7 +112,7 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
             stream = getStreamById(event->deviceHandle.xLinkFD, event->header.streamId);
 
             if(!stream) {
-                mvLog(MVLOG_DEBUG, "stream %d has been closed!\n", event->header.streamId);
+                mvLog(MVLOG_DEBUG, "stream %d has been closed!", event->header.streamId);
                 XLINK_SET_EVENT_FAILED_AND_SERVE(event);
                 break;
             }
@@ -128,16 +128,16 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
             event->header.flags.bitField.localServe = 0;
 
             if(!isStreamSpaceEnoughFor(stream, event->header.size)){
-                mvLog(MVLOG_DEBUG,"local NACK RTS. stream '%s' is full (event %d)\n", stream->name, event->header.id);
+                mvLog(MVLOG_DEBUG,"local NACK RTS. stream '%s' is full (event %d)", stream->name, event->header.id);
                 event->header.flags.bitField.block = 1;
                 event->header.flags.bitField.localServe = 1;
                 // TODO: easy to implement non-blocking read here, just return nack
-                mvLog(MVLOG_WARN, "Blocked event would cause dispatching thread to wait on semaphore infinitely\n");
+                mvLog(MVLOG_WARN, "Blocked event would cause dispatching thread to wait on semaphore infinitely");
             }else{
                 event->header.flags.bitField.block = 0;
                 stream->remoteFillLevel += event->header.size;
                 stream->remoteFillPacketLevel++;
-                mvLog(MVLOG_DEBUG,"S%d: Got local write of %ld , remote fill level %ld out of %ld %ld\n",
+                mvLog(MVLOG_DEBUG,"S%d: Got local write of %ld , remote fill level %ld out of %ld %ld",
                       event->header.streamId, event->header.size, stream->remoteFillLevel, stream->writeSize, stream->readSize);
             }
             releaseStream(stream);
@@ -147,7 +147,7 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
         {
             stream = getStreamById(event->deviceHandle.xLinkFD, event->header.streamId);
             if(!stream) {
-                mvLog(MVLOG_DEBUG, "stream %d has been closed!\n", event->header.streamId);
+                mvLog(MVLOG_DEBUG, "stream %d has been closed!", event->header.streamId);
                 XLINK_SET_EVENT_FAILED_AND_SERVE(event);
                 break;
             }
@@ -205,11 +205,11 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
                                                             event->header.streamName,
                                                             event->header.size, 0,
                                                             INVALID_STREAM_ID);
-            mvLog(MVLOG_DEBUG, "XLINK_CREATE_STREAM_REQ - stream has been just opened with id %ld\n",
+            mvLog(MVLOG_DEBUG, "XLINK_CREATE_STREAM_REQ - stream has been just opened with id %ld",
                   event->header.streamId);
 #else
             mvLog(MVLOG_DEBUG, "XLINK_CREATE_STREAM_REQ - do nothing. Stream will be "
-                  "opened with forced id accordingly to response from the host\n");
+                  "opened with forced id accordingly to response from the host");
 #endif
             break;
         }
@@ -233,13 +233,13 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
         case XLINK_RESET_REQ:
         {
             XLINK_EVENT_ACKNOWLEDGE(event);
-            mvLog(MVLOG_DEBUG,"XLINK_RESET_REQ - do nothing\n");
+            mvLog(MVLOG_DEBUG,"XLINK_RESET_REQ - do nothing");
             break;
         }
         case XLINK_PING_REQ:
         {
             XLINK_EVENT_ACKNOWLEDGE(event);
-            mvLog(MVLOG_DEBUG,"XLINK_PING_REQ - do nothing\n");
+            mvLog(MVLOG_DEBUG,"XLINK_PING_REQ - do nothing");
             break;
         }
         case XLINK_WRITE_RESP:
@@ -257,7 +257,7 @@ int dispatcherLocalEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response)
         default:
         {
             mvLog(MVLOG_ERROR,
-                  "Fail to get response for local event. type: %d, stream name: %s\n",
+                  "Fail to get response for local event. type: %d, stream name: %s",
                   event->header.type, event->header.streamName);
             ASSERT_XLINK(0);
         }
@@ -270,7 +270,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
 {
     response->header.id = event->header.id;
     response->header.flags.raw = 0;
-    mvLog(MVLOG_DEBUG, "%s\n",TypeToStr(event->header.type));
+    mvLog(MVLOG_DEBUG, "%s",TypeToStr(event->header.type));
 
     switch (event->header.type)
     {
@@ -289,7 +289,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
                                                 response->header.streamId,
                                                 event->deviceHandle.xLinkFD);
                 (void) xxx;
-                mvLog(MVLOG_DEBUG,"unblocked from stream %d %d\n",
+                mvLog(MVLOG_DEBUG,"unblocked from stream %d %d",
                     (int)response->header.streamId, (int)xxx);
             }
             break;
@@ -305,7 +305,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             stream->remoteFillLevel -= event->header.size;
             stream->remoteFillPacketLevel--;
 
-            mvLog(MVLOG_DEBUG,"S%d: Got remote release of %ld, remote fill level %ld out of %ld %ld\n",
+            mvLog(MVLOG_DEBUG,"S%d: Got remote release of %ld, remote fill level %ld out of %ld %ld",
                   event->header.streamId, event->header.size, stream->remoteFillLevel, stream->writeSize, stream->readSize);
             releaseStream(stream);
 
@@ -314,7 +314,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             //with every released packet check if the stream is already marked for close
             if (stream->closeStreamInitiated && stream->localFillLevel == 0)
             {
-                mvLog(MVLOG_DEBUG,"%s() Unblock close STREAM\n", __func__);
+                mvLog(MVLOG_DEBUG,"%s() Unblock close STREAM", __func__);
                 DispatcherUnblockEvent(-1,
                                        XLINK_CLOSE_STREAM_REQ,
                                        event->header.streamId,
@@ -332,7 +332,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             stream->remoteFillLevel -= event->header.size;
             stream->remoteFillPacketLevel--;
 
-            mvLog(MVLOG_DEBUG,"S%d: Got remote release of %ld, remote fill level %ld out of %ld %ld\n",
+            mvLog(MVLOG_DEBUG,"S%d: Got remote release of %ld, remote fill level %ld out of %ld %ld",
                   event->header.streamId, event->header.size, stream->remoteFillLevel, stream->writeSize, stream->readSize);
             releaseStream(stream);
 
@@ -341,7 +341,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             //with every released packet check if the stream is already marked for close
             if (stream->closeStreamInitiated && stream->localFillLevel == 0)
             {
-                mvLog(MVLOG_DEBUG,"%s() Unblock close STREAM\n", __func__);
+                mvLog(MVLOG_DEBUG,"%s() Unblock close STREAM", __func__);
                 int xxx = DispatcherUnblockEvent(-1,
                                                  XLINK_CLOSE_STREAM_REQ,
                                                  event->header.streamId,
@@ -375,7 +375,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             mv_strncpy(response->header.streamName, MAX_STREAM_NAME_LENGTH,
                        event->header.streamName, MAX_STREAM_NAME_LENGTH - 1);
             response->header.size = event->header.size;
-            mvLog(MVLOG_DEBUG,"creating stream %x\n", (int)response->header.streamId);
+            mvLog(MVLOG_DEBUG,"creating stream %x", (int)response->header.streamId);
             break;
         case XLINK_CLOSE_STREAM_REQ:
         {
@@ -389,7 +389,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
                 //if we have sent a NACK before, when the event gets unblocked
                 //the stream might already be unavailable
                 XLINK_EVENT_ACKNOWLEDGE(response);
-                mvLog(MVLOG_DEBUG,"%s() got a close stream on aready closed stream\n", __func__);
+                mvLog(MVLOG_DEBUG,"%s() got a close stream on aready closed stream", __func__);
             } else {
                 if (stream->localFillLevel == 0)
                 {
@@ -412,7 +412,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
                 }
                 else
                 {
-                    mvLog(MVLOG_DEBUG,"%s():fifo is NOT empty returning NACK \n", __func__);
+                    mvLog(MVLOG_DEBUG,"%s():fifo is NOT empty returning NACK", __func__);
                     XLINK_EVENT_NOT_ACKNOWLEDGE(response);
                     stream->closeStreamInitiated = 1;
                 }
@@ -428,7 +428,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             sem_post(&pingSem);
             break;
         case XLINK_RESET_REQ:
-            mvLog(MVLOG_DEBUG,"reset request - received! Sending ACK *****\n");
+            mvLog(MVLOG_DEBUG,"reset request - received! Sending ACK *****");
             XLINK_EVENT_ACKNOWLEDGE(response);
             response->header.type = XLINK_RESET_RESP;
             response->deviceHandle = event->deviceHandle;
@@ -453,7 +453,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
             XLINK_RET_IF(response->header.streamId
                 == INVALID_STREAM_ID);
             mvLog(MVLOG_DEBUG, "XLINK_CREATE_STREAM_REQ - stream has been just opened "
-                  "with forced id=%ld accordingly to response from the host\n",
+                  "with forced id=%ld accordingly to response from the host",
                   response->header.streamId);
 #endif
             response->deviceHandle = event->deviceHandle;
@@ -485,7 +485,7 @@ int dispatcherRemoteEventGetResponse(xLinkEvent_t* event, xLinkEvent_t* response
         default:
         {
             mvLog(MVLOG_ERROR,
-                "Fail to get response for remote event. type: %d, stream name: %s\n",
+                "Fail to get response for remote event. type: %d, stream name: %s",
                 event->header.type, event->header.streamName);
             ASSERT_XLINK(0);
         }
@@ -537,7 +537,7 @@ void dispatcherCloseLink(void* fd, int fullClose)
     }
 
     if(XLink_sem_destroy(&link->dispatcherClosedSem)) {
-        mvLog(MVLOG_DEBUG, "Cannot destroy dispatcherClosedSem\n");
+        mvLog(MVLOG_DEBUG, "Cannot destroy dispatcherClosedSem");
     }
 }
 
@@ -560,7 +560,7 @@ int isStreamSpaceEnoughFor(streamDesc_t* stream, uint32_t size)
 {
     if(stream->remoteFillPacketLevel >= XLINK_MAX_PACKETS_PER_STREAM ||
        stream->remoteFillLevel + size > stream->writeSize){
-        mvLog(MVLOG_DEBUG, "S%d: Not enough space in stream '%s' for %ld: PKT %ld, FILL %ld SIZE %ld\n",
+        mvLog(MVLOG_DEBUG, "S%d: Not enough space in stream '%s' for %ld: PKT %ld, FILL %ld SIZE %ld",
               stream->id, stream->name, size, stream->remoteFillPacketLevel, stream->remoteFillLevel, stream->writeSize);
         return 0;
     }
@@ -592,7 +592,7 @@ streamPacketDesc_t* movePacketFromStream(streamDesc_t* stream)
         ret = malloc(sizeof(streamPacketDesc_t));
         if (!ret)
         {
-            mvLog(MVLOG_FATAL, "out of memory to move packet from stream\n");
+            mvLog(MVLOG_FATAL, "out of memory to move packet from stream");
             return NULL;
         }
         ret->data = NULL;
@@ -617,12 +617,12 @@ int releasePacketFromStream(streamDesc_t* stream, uint32_t* releasedSize)
 {
     streamPacketDesc_t* currPack = &stream->packets[stream->firstPacket];
     if(stream->blockedPackets == 0){
-        mvLog(MVLOG_ERROR,"There is no packet to release\n");
+        mvLog(MVLOG_ERROR,"There is no packet to release");
         return 0; // ignore this, although this is a big problem on application side
     }
 
     stream->localFillLevel -= currPack->length;
-    mvLog(MVLOG_DEBUG, "S%d: Got release of %ld , current local fill level is %ld out of %ld %ld\n",
+    mvLog(MVLOG_DEBUG, "S%d: Got release of %ld , current local fill level is %ld out of %ld %ld",
           stream->id, currPack->length, stream->localFillLevel, stream->readSize, stream->writeSize);
 
     XLinkPlatformDeallocateData(currPack->data,
@@ -638,7 +638,7 @@ int releasePacketFromStream(streamDesc_t* stream, uint32_t* releasedSize)
 
 int releaseSpecificPacketFromStream(streamDesc_t* stream, uint32_t* releasedSize, uint8_t* data) {
     if (stream->blockedPackets == 0) {
-        mvLog(MVLOG_ERROR,"There is no packet to release\n");
+        mvLog(MVLOG_ERROR,"There is no packet to release");
         return 0; // ignore this, although this is a big problem on application side
     }
 
@@ -655,12 +655,12 @@ int releaseSpecificPacketFromStream(streamDesc_t* stream, uint32_t* releasedSize
 
     streamPacketDesc_t* currPack = &stream->packets[packetId];
     if (currPack->length == 0) {
-        mvLog(MVLOG_ERROR, "Packet with ID %d is empty\n", packetId);
+        mvLog(MVLOG_ERROR, "Packet with ID %d is empty", packetId);
     }
 
     stream->localFillLevel -= currPack->length;
 
-  mvLog(MVLOG_DEBUG, "S%d: Got release of %ld , current local fill level is %ld out of %ld %ld\n",
+  mvLog(MVLOG_DEBUG, "S%d: Got release of %ld , current local fill level is %ld out of %ld %ld",
           stream->id, currPack->length, stream->localFillLevel, stream->readSize, stream->writeSize);
     XLinkPlatformDeallocateData(currPack->data,
                                 ALIGN_UP_INT32((int32_t) currPack->length, __CACHE_LINE_SIZE), __CACHE_LINE_SIZE);
@@ -703,7 +703,7 @@ int addNewPacketToStream(streamDesc_t* stream, void* buffer, uint32_t size) {
 int handleIncomingEvent(xLinkEvent_t* event) {
     //this function will be dependent whether this is a client or a Remote
     //specific actions to this peer
-    mvLog(MVLOG_DEBUG, "%s, size %u, streamId %u.\n", TypeToStr(event->header.type), event->header.size, event->header.streamId);
+    mvLog(MVLOG_DEBUG, "%s, size %u, streamId %u.", TypeToStr(event->header.type), event->header.size, event->header.streamId);
 
     ASSERT_XLINK(event->header.type >= XLINK_WRITE_REQ
                && event->header.type != XLINK_REQUEST_LAST
@@ -719,19 +719,19 @@ int handleIncomingEvent(xLinkEvent_t* event) {
     ASSERT_XLINK(stream);
 
     stream->localFillLevel += event->header.size;
-    mvLog(MVLOG_DEBUG,"S%u: Got write of %u, current local fill level is %u out of %u %u\n",
+    mvLog(MVLOG_DEBUG,"S%u: Got write of %u, current local fill level is %u out of %u %u",
           event->header.streamId, event->header.size, stream->localFillLevel, stream->readSize, stream->writeSize);
 
     void* buffer = XLinkPlatformAllocateData(ALIGN_UP(event->header.size, __CACHE_LINE_SIZE), __CACHE_LINE_SIZE);
     XLINK_OUT_WITH_LOG_IF(buffer == NULL,
-        mvLog(MVLOG_FATAL,"out of memory to receive data of size = %zu\n", event->header.size));
+        mvLog(MVLOG_FATAL,"out of memory to receive data of size = %zu", event->header.size));
 
     const int sc = XLinkPlatformRead(&event->deviceHandle, buffer, event->header.size);
-    XLINK_OUT_WITH_LOG_IF(sc < 0, mvLog(MVLOG_ERROR,"%s() Read failed %d\n", __func__, sc));
+    XLINK_OUT_WITH_LOG_IF(sc < 0, mvLog(MVLOG_ERROR,"%s() Read failed %d", __func__, sc));
 
     event->data = buffer;
     XLINK_OUT_WITH_LOG_IF(addNewPacketToStream(stream, buffer, event->header.size),
-        mvLog(MVLOG_WARN,"No more place in stream. release packet\n"));
+        mvLog(MVLOG_WARN,"No more place in stream. release packet"));
     rc = 0;
 
 XLINK_OUT:

--- a/src/shared/XLinkLog.c
+++ b/src/shared/XLinkLog.c
@@ -124,7 +124,7 @@ void XLinkLogGetThreadName(char *buf, size_t len){
 #ifdef __shave__
 __attribute__((section(".laststage")))
 #endif
-int __attribute__ ((unused))
+int MVLOG_ATTRIBUTE((unused))
 logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line,
           const char * format, ...)
 {

--- a/src/shared/XLinkPrivateDefines.c
+++ b/src/shared/XLinkPrivateDefines.c
@@ -37,7 +37,7 @@ static streamId_t getNextStreamUniqueId(xLinkDesc_t *link);
 streamId_t XLinkAddOrUpdateStream(void *fd, const char *name,
     uint32_t writeSize, uint32_t readSize, streamId_t forcedId)
 {
-    mvLog(MVLOG_DEBUG, "name: %s, writeSize: %ld, readSize: %ld, forcedId: %ld\n",
+    mvLog(MVLOG_DEBUG, "name: %s, writeSize: %ld, readSize: %ld, forcedId: %ld",
         name, writeSize, readSize, forcedId);
 
     streamId_t retStreamId = INVALID_STREAM_ID;
@@ -63,7 +63,7 @@ streamId_t XLinkAddOrUpdateStream(void *fd, const char *name,
         }
 
         // XLINK_OUT_WITH_LOG_IF(streamAlreadyExists,
-        //     mvLog(MVLOG_ERROR, "Stream with name:%s already exists: id=%ld\n", name, stream->id));
+        //     mvLog(MVLOG_ERROR, "Stream with name:%s already exists: id=%ld", name, stream->id));
 
         // if(streamAlreadyExists){
         //     //stream->writeSize = writeSize;
@@ -104,7 +104,7 @@ streamId_t XLinkAddOrUpdateStream(void *fd, const char *name,
     }
 
     retStreamId = stream->id;
-    mvLog(MVLOG_DEBUG, "The stream \"%s\"  created, id = %u, writeSize = %d, readSize = %d\n",
+    mvLog(MVLOG_DEBUG, "The stream \"%s\"  created, id = %u, writeSize = %d, readSize = %d",
           stream->name, stream->id, stream->writeSize, stream->readSize);
 
 XLINK_OUT:
@@ -136,7 +136,7 @@ XLinkError_t getNextAvailableStreamIndex(xLinkDesc_t* link, int* out_id)
         }
     }
 
-    mvLog(MVLOG_DEBUG,"No next available stream!\n");
+    mvLog(MVLOG_DEBUG,"No next available stream!");
     return X_LINK_ERROR;
 }
 
@@ -166,7 +166,7 @@ streamId_t getNextStreamUniqueId(xLinkDesc_t *link)
             curr = 0;
         }
     } while (start != curr);
-    mvLog(MVLOG_ERROR, "%s():- no next available stream unique id!\n", __func__);
+    mvLog(MVLOG_ERROR, "%s():- no next available stream unique id!", __func__);
     return INVALID_STREAM_ID;
 }
 

--- a/src/shared/XLinkPrivateFields.c
+++ b/src/shared/XLinkPrivateFields.c
@@ -76,7 +76,7 @@ streamDesc_t* getStreamById(void* fd, streamId_t id)
             while(((rc = XLink_sem_wait(&link->availableStreams[stream].sem)) == -1) && errno == EINTR)
                 continue;
             if (rc) {
-                mvLog(MVLOG_ERROR,"can't wait semaphore\n");
+                mvLog(MVLOG_ERROR,"can't wait semaphore");
                 return NULL;
             }
             return &link->availableStreams[stream];
@@ -96,7 +96,7 @@ streamDesc_t* getStreamByName(xLinkDesc_t* link, const char* name)
             while(((rc = XLink_sem_wait(&link->availableStreams[stream].sem)) == -1) && errno == EINTR)
                 continue;
             if (rc) {
-                mvLog(MVLOG_ERROR,"can't wait semaphore\n");
+                mvLog(MVLOG_ERROR,"can't wait semaphore");
                 return NULL;
             }
             return &link->availableStreams[stream];
@@ -111,13 +111,13 @@ void releaseStream(streamDesc_t* stream)
         XLink_sem_post(&stream->sem);
     }
     else {
-        mvLog(MVLOG_DEBUG,"trying to release a semaphore for a released stream\n");
+        mvLog(MVLOG_DEBUG,"trying to release a semaphore for a released stream");
     }
 }
 
 xLinkState_t getXLinkState(xLinkDesc_t* link)
 {
     XLINK_RET_ERR_IF(link == NULL, XLINK_NOT_INIT);
-    mvLog(MVLOG_DEBUG,"%s() link %p link->peerState %d\n", __func__,link, link->peerState);
+    mvLog(MVLOG_DEBUG,"%s() link %p link->peerState %d", __func__,link, link->peerState);
     return link->peerState;
 }

--- a/src/shared/XLinkStream.c
+++ b/src/shared/XLinkStream.c
@@ -17,13 +17,13 @@
 
 XLinkError_t XLinkStreamInitialize(
     streamDesc_t* stream, streamId_t id, const char* name) {
-    mvLog(MVLOG_DEBUG, "name: %s, id: %ld\n", name, id);
+    mvLog(MVLOG_DEBUG, "name: %s, id: %ld", name, id);
     ASSERT_XLINK(stream);
 
     memset(stream, 0, sizeof(*stream));
 
     if (XLink_sem_init(&stream->sem, 0, 0)) {
-        mvLog(MVLOG_ERROR, "Cannot initialize semaphore\n");
+        mvLog(MVLOG_ERROR, "Cannot initialize semaphore");
         return X_LINK_ERROR;
     }
 
@@ -40,7 +40,7 @@ void XLinkStreamReset(streamDesc_t* stream) {
     }
 
     if(XLink_sem_destroy(&stream->sem)) {
-        mvLog(MVLOG_DEBUG, "Cannot destroy semaphore\n");
+        mvLog(MVLOG_DEBUG, "Cannot destroy semaphore");
     }
 
     // sets all stream fields, including the packets circular buffer to NULL

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 macro(add_test test_name test_src)
     add_executable(${test_name} ${test_src})
     target_link_libraries(${test_name} ${TARGET_NAME})
-    set_property(TARGET ${test_name} PROPERTY CXX_STANDARD 11)
+    set_property(TARGET ${test_name} PROPERTY CXX_STANDARD 14)
     set_property(TARGET ${test_name} PROPERTY CXX_STANDARD_REQUIRED ON)
     set_property(TARGET ${test_name} PROPERTY CXX_EXTENSIONS OFF)
 

--- a/tests/multiple_open_stream.cpp
+++ b/tests/multiple_open_stream.cpp
@@ -37,7 +37,7 @@ int main() {
     XLinkInitialize(&gHandler);
 
     // Search for booted device
-    deviceDesc_t deviceDesc, inDeviceDesc;
+    deviceDesc_t deviceDesc = {}, inDeviceDesc = {};
     inDeviceDesc.protocol = X_LINK_ANY_PROTOCOL;
     inDeviceDesc.state = X_LINK_BOOTED;
     if(X_LINK_SUCCESS != XLinkFindFirstSuitableDevice(inDeviceDesc, &deviceDesc)){


### PR DESCRIPTION
Adds c++ wrappers for the minimum set of features needed without introducing major Xlink code refactoring. fixes #59 
I can't move much further until the questions below are answered.

* new `dai::libusb` namespace
* Uses the constructor approach for wrappers (not factory)
* Added `usb_error` for exceptions
* Added `usb_context`, `usb_device`, `device_list`, `device_handle`, `config_descriptor`
* Added methods like `device_handle::claim_interface()`, `device_handle::set_configuration()`, etc. to manage interfaces *and* fix resource leak bugs I found
* Workaround for thread-unsafe `libusb_get_device_list()`

#### Questions

1. can we shift XLink to be a C++14 project? the cmake's in XLink are still set to c++11. If no, then I'll need to change some code.
2. ~what code should make `mvLog` entries. Should that be in the wrapper? Or should the Caller do it with `catch() { mvLog("had an error: " + myexception.what()); }`. Pros and Cons for both. This is more a style and feature choice.~ The wrapper classes do the logging as it matched the majority of use cases.
3. ~Can I remove `extern C` from `refLibusbDeviceByName()`? I don't see a need for it. Does the device firmware code need it?~ I removed it.
4. Code comments in `refLibusbDeviceByName()` say it filters by Myraid devices. It actually doesn't. This can be added if needed.
5. ~I would like to pass between a few functions wrapper classes instead of raw pointers. Does your team have any concerns?~ Already changed some func signatures to use the new classes; usually as a reference.