### PR TITLE
Timesync optimization fix

### DIFF
--- a/include/XLink/XLinkPrivateDefines.h
+++ b/include/XLink/XLinkPrivateDefines.h
@@ -134,8 +134,9 @@ typedef struct xLinkEventHeader_t{
     eventId_t           id;
     xLinkEventType_t    type;
     char                streamName[MAX_STREAM_NAME_LENGTH];
-    uint64_t            tsec;
     uint32_t            tnsec;
+    uint32_t            tsecLsb;
+    uint32_t            tsecMsb;
     streamId_t          streamId;
     uint32_t            size;
     union{

--- a/src/shared/XLinkAssertions.cpp
+++ b/src/shared/XLinkAssertions.cpp
@@ -4,7 +4,7 @@
 
 static_assert(offsetof(xLinkEventHeader_t, id) == 0, "Offset to id is not 0");
 static_assert(offsetof(xLinkEventHeader_t, type) == 4, "Offset to type is not 4");
-static_assert(offsetof(xLinkEventHeader_t, streamName) == 8, "Offset to type is not 8");
-static_assert(offsetof(xLinkEventHeader_t, tnsec) == 60, "Offset to type is not 60");
-static_assert(offsetof(xLinkEventHeader_t, tsecLsb) == 64, "Offset to type is not 64");
-static_assert(offsetof(xLinkEventHeader_t, tsecMsb) == 68, "Offset to type is not 68");
+static_assert(offsetof(xLinkEventHeader_t, streamName) == 8, "Offset to streamName is not 8");
+static_assert(offsetof(xLinkEventHeader_t, tnsec) == 60, "Offset to tnsec is not 60");
+static_assert(offsetof(xLinkEventHeader_t, tsecLsb) == 64, "Offset to tsecLsb is not 64");
+static_assert(offsetof(xLinkEventHeader_t, tsecMsb) == 68, "Offset to tsecMsb is not 68");

--- a/src/shared/XLinkAssertions.cpp
+++ b/src/shared/XLinkAssertions.cpp
@@ -1,4 +1,3 @@
-#include <bits/stdint-uintn.h>
 #include <cstddef>
 #include "XLinkPrivateDefines.h"
 

--- a/src/shared/XLinkAssertions.cpp
+++ b/src/shared/XLinkAssertions.cpp
@@ -1,0 +1,10 @@
+#include <bits/stdint-uintn.h>
+#include <cstddef>
+#include "XLinkPrivateDefines.h"
+
+static_assert(offsetof(xLinkEventHeader_t, id) == 0, "Offset to id is not 0");
+static_assert(offsetof(xLinkEventHeader_t, type) == 4, "Offset to type is not 4");
+static_assert(offsetof(xLinkEventHeader_t, streamName) == 8, "Offset to type is not 8");
+static_assert(offsetof(xLinkEventHeader_t, tnsec) == 60, "Offset to type is not 60");
+static_assert(offsetof(xLinkEventHeader_t, tsecLsb) == 64, "Offset to type is not 64");
+static_assert(offsetof(xLinkEventHeader_t, tsecMsb) == 68, "Offset to type is not 68");

--- a/src/shared/XLinkDispatcher.c
+++ b/src/shared/XLinkDispatcher.c
@@ -917,7 +917,8 @@ static int dispatcherResponseServe(xLinkEventPriv_t * event, xLinkSchedulerState
                   TypeToStr(header->type));
             //propagate back flags
             header->flags = evHeader->flags;
-            header->tsec = evHeader->tsec;
+            header->tsecLsb = evHeader->tsecLsb;
+            header->tsecMsb = evHeader->tsecMsb;
             header->tnsec = evHeader->tnsec;
             postAndMarkEventServed(&curr->lQueue.q[i]);
             break;


### PR DESCRIPTION
tsec param split in two to fix struct being bigger due to alignment