### PR TITLE
Update README.md with reference to XLink origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # XLink
-This is a "fork" of openvino repositories third party dependency - XLink.
+
+This is a "fork" of a library that used to be openvino repositories third party dependency - XLink. The library was removed in https://github.com/openvinotoolkit/openvino/pull/15131 .
 
 # Changes
 Some tweaks to CMake files to enable installation of this target and being able to be used with Hunter package manager

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XLink
 
-This is a "fork" of a library that used to be openvino repositories third party dependency - XLink. The library was removed in https://github.com/openvinotoolkit/openvino/pull/15131 .
+This is a "fork" of a library that used to be openvino repositories third party dependency - XLink. The original library was removed form openvino repositories in https://github.com/openvinotoolkit/openvino/pull/15131 .
 
 # Changes
 Some tweaks to CMake files to enable installation of this target and being able to be used with Hunter package manager

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XLink
 
-This is a "fork" of a library that used to be openvino repositories third party dependency - XLink. The original library was removed form openvino repositories in https://github.com/openvinotoolkit/openvino/pull/15131 .
+This is a "fork" of a library that used to be openvino repositories third party dependency - XLink. The original library was removed from openvino repositories in https://github.com/openvinotoolkit/openvino/pull/15131 .
 
 # Changes
 Some tweaks to CMake files to enable installation of this target and being able to be used with Hunter package manager


### PR DESCRIPTION
It took me a while to understand where XLink does come from. The good news is that in a sense this repo is not a fork anymore, as there is no other public XLink repo that I could found.