### PR TITLE
Enable support for BUILD_SHARED_LIBS on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(XLINK_LIBUSB_LOCAL "" CACHE STRING "Path to local libub source to use instea
 # Debug option
 option(XLINK_LIBUSB_SYSTEM "Use system libusb library instead of Hunter" OFF)
 
-# Specify exporting all symbols on Windows (WIP: shared library on windows doesn't yet work fully (eg logging))
+# Specify exporting all symbols on Windows
 if(WIN32 AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON CACHE BOOL "")
 endif()
@@ -65,7 +65,10 @@ get_cmake_property(is_multi_config GENERATOR_IS_MULTI_CONFIG)
 if(is_multi_config)
     set_target_properties(${TARGET_NAME} PROPERTIES DEBUG_POSTFIX "d")
 endif()
-
+# Define export header to support shared library on Windows
+include(GenerateExportHeader)
+generate_export_header(${TARGET_NAME}
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Export.h)
 # Add dependencies
 include(cmake/XLinkDependencies.cmake)
 
@@ -133,6 +136,7 @@ add_library(${TARGET_PUBLIC_NAME} INTERFACE)
 target_include_directories(${TARGET_PUBLIC_NAME} INTERFACE
     "$<INSTALL_INTERFACE:include>"
     "$<BUILD_INTERFACE:${XLINK_INCLUDE}>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
 )
 
 # Link to headers (public, as itself also needs the headers)
@@ -243,6 +247,12 @@ install(
 )
 #Install include folder
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# Install generated export header
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}Export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/XLink
+)
+
 # Install Hunter dependencies
 if(XLINK_ENABLE_LIBUSB)
     if(NOT XLINK_LIBUSB_LOCAL AND NOT XLINK_LIBUSB_SYSTEM)

--- a/include/XLink/XLinkLog.h
+++ b/include/XLink/XLinkLog.h
@@ -30,6 +30,8 @@ extern "C" {
 #include <stdarg.h>
 #include <inttypes.h>
 
+#include "XLinkExport.h"
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -72,8 +74,8 @@ FUNCATTR_WEAK mvLog_t __attribute__ ((weak)) MVLOGLEVEL(MVLOG_UNIT_NAME) = MVLOG
 #define UNIT_NAME_STR MVLOG_STR(MVLOG_UNIT_NAME)
 
 
-extern mvLog_t MVLOGLEVEL(global);
-extern mvLog_t MVLOGLEVEL(default);
+extern XLINK_EXPORT mvLog_t MVLOGLEVEL(global);
+extern XLINK_EXPORT mvLog_t MVLOGLEVEL(default);
 
 int __attribute__ ((unused)) logprintf(mvLog_t curLogLvl, mvLog_t lvl, const char * func, const int line, const char * format, ...);
 


### PR DESCRIPTION
The variable `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` used to support `BUILD_SHARED_LIBS` works fine for all symbols, except static/global variable (see https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html and https://www.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/).

For this reason, the global symbols need to be explicitly exported via `__declspec(dllexport)` and `__declspec(dllimport)`, that are added via a `XLinkExport.h` header generated by the `generate_export_header` CMake function. 

Without this fix, linking an executable against the `XLink` shared library on Windows fails with error:
~~~
FAILED: examples/boot_firmware.exe
C:\Windows\system32\cmd.exe /C "cd . && D:\miniforge3\envs\idjlluxonisenv\Library\bin\cmake.exe -E vs_link_exe --intdir=examples\CMakeFiles\boot_firmware.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~4\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo examples\CMakeFiles\boot_firmware.dir\boot_firmware.cpp.obj  /out:examples\boot_firmware.exe /implib:examples\boot_firmware.lib /pdb:examples\boot_firmware.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console  XLink.lib  D:\miniforge3\envs\idjlluxonisenv\Library\lib\libusb-1.0.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && C:\Windows\system32\cmd.exe /C "cd /D D:\src\depthaicorestint1\XLink\build\examples && D:\miniforge3\envs\idjlluxonisenv\Library\bin\cmake.exe -E copy_if_different D:/src/depthaicorestint1/XLink/build/XLink.dll D:/src/depthaicorestint1/XLink/build/examples""
LINK: command "C:\PROGRA~2\MICROS~4\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo examples\CMakeFiles\boot_firmware.dir\boot_firmware.cpp.obj /out:examples\boot_firmware.exe /implib:examples\boot_firmware.lib /pdb:examples\boot_firmware.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console XLink.lib D:\miniforge3\envs\idjlluxonisenv\Library\lib\libusb-1.0.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST:EMBED,ID=1" failed (exit code 1120) with the following output:
boot_firmware.cpp.obj : error LNK2019: unresolved external symbol mvLogLevel_default referenced in function main
examples\boot_firmware.exe : fatal error LNK1120: 1 unresolved externals
[35/35] Linking CXX executable tests\multithreading_search_test.exe
ninja: build stopped: subcommand failed.
~~~
