### PR TITLE
cmake: Bump CMakeLists.txt to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # With additions of Luxonis
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 include("cmake/HunterGate.cmake")
 HunterGate(


### PR DESCRIPTION
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.