### PR TITLE
pcie: Fix sprintf with XLINK_MAX_NAME_SIZE

### DIFF
--- a/src/pc/protocols/pcie_host.c
+++ b/src/pc/protocols/pcie_host.c
@@ -466,7 +466,9 @@ pcieHostError_t pcie_find_device_port(
         if (strncmp(entry->d_name, "mxlk", 4) == 0)
         {
             // Save name
-            snprintf(found_device, name_length, "/dev/%s", entry->d_name);
+            snprintf(found_device, XLINK_MAX_NAME_SIZE, "/dev/%.*s",
+                     (int)(XLINK_MAX_NAME_SIZE - 6), entry->d_name);
+
             // Get state of device
             if (pcie_get_device_state(found_device, &platformState) != 0) {
                 closedir(dp);


### PR DESCRIPTION
XLink/src/pc/protocols/pcie_host.c:469:55: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 59 [-Wformat-truncation=]
  469 |             snprintf(found_device, name_length, "/dev/%s", entry->d_name);
