### PR TITLE
[RVC2] Attempt to fix device bad state (USB/UNBOOTED)

### DIFF
--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -27,6 +27,7 @@
 constexpr static int MAXIMUM_PORT_NUMBERS = 7;
 using VidPid = std::pair<uint16_t, uint16_t>;
 static const int MX_ID_TIMEOUT_MS = 100;
+static const int MX_ID_NOPS_TIMEOUT_MS = 500;
 
 static constexpr auto DEFAULT_OPEN_TIMEOUT = std::chrono::seconds(5);
 static constexpr auto DEFAULT_WRITE_TIMEOUT = 2000;
@@ -311,12 +312,14 @@ libusb_error getLibusbDeviceMxId(XLinkDeviceState_t state, std::string devicePat
         libusb_device_handle *handle = nullptr;
         int libusb_rc = LIBUSB_SUCCESS;
 
-        // Retry getting MX ID for 15ms
-        const std::chrono::milliseconds RETRY_TIMEOUT{15}; // 15ms
+        // Retry getting MX ID for 1 second
+        const std::chrono::milliseconds RETRY_TIMEOUT{1000}; // 1000ms
         const std::chrono::microseconds SLEEP_BETWEEN_RETRIES{100}; // 100us
 
+        int tryCount = 0;
         auto t1 = std::chrono::steady_clock::now();
         do {
+            tryCount++;
 
             // Open device - if not already
             if(handle == nullptr){
@@ -389,6 +392,27 @@ libusb_error getLibusbDeviceMxId(XLinkDeviceState_t state, std::string devicePat
 
                 // ///////////////////////
                 // Start
+                // If first attempt was unsuccessful, try sending NOPs to clear out potential bad state
+                if (tryCount > 1) {
+                    int size = 256 * 1024 + 16;
+                    uint8_t *nops = (uint8_t *)calloc(size, 1);
+                    if (nops) {
+                        transferred = 0;
+                        libusb_rc = libusb_bulk_transfer(handle, send_ep, nops, size, &transferred, MX_ID_NOPS_TIMEOUT_MS);
+                        mvLog(MVLOG_DEBUG, "Sending NOPs to %s\n", devicePath.c_str());
+                        free(nops);
+                        if (libusb_rc < 0 || size != transferred) {
+                            mvLog(MVLOG_ERROR, "libusb_bulk_transfer (%s), transfer: %d, expected: %d", xlink_libusb_strerror(libusb_rc), transferred, size);
+                            // Mark as error and retry
+                            libusb_rc = -1;
+                            // retry
+                            std::this_thread::sleep_for(SLEEP_BETWEEN_RETRIES);
+                            continue;
+                        }
+                    }
+                }
+
+                mvLog(MVLOG_DEBUG, "Sending MXID read to %s, try %d\n", devicePath.c_str(), tryCount);
                 // WD Protection & MXID Retrieval Command
                 transferred = 0;
                 libusb_rc = libusb_bulk_transfer(handle, send_ep, ((uint8_t*) usb_mx_id_get_payload()), usb_mx_id_get_payload_size(), &transferred, MX_ID_TIMEOUT_MS);


### PR DESCRIPTION
If a bootup was interrupted in the middle of sending the ~25MiB payload, the device may fail to boot again, with depthai logs:
`[2025-08-07 5:51:26.110] [depthai] [warning] Skipping X_LINK_UNBOOTED device with name "1.3.2" ()`
`[2025-08-07 5:51:27.246] [depthai] [warning] skipping X_LINK_UNBOOTED device having name "1.3.2"`
 and required a power cycle.

This changeset tries to recover the device, however it may not work if another bootup attempt was performed after the interrupted one with an old library not including this fix (as that second bootup attempt could have worsened device state).