### PR TITLE
Detect local connection

### DIFF
--- a/include/XLink/XLinkPublicDefines.h
+++ b/include/XLink/XLinkPublicDefines.h
@@ -172,6 +172,14 @@ typedef struct XLinkGlobalHandler_t
     int loglevel;
     int protocol;
     //Deprecated fields. End.
+
+    /**
+     * Indicates if the XLink connection is 
+     * between the same host.
+     * aka: the protocol is X_LINK_LOCAL_SHDMEM
+     * or the client IP is the same as one of our IPs.
+     */ 
+    bool isLocalConnection;
 } XLinkGlobalHandler_t;
 
 typedef struct

--- a/src/pc/protocols/local_memshd.cpp
+++ b/src/pc/protocols/local_memshd.cpp
@@ -6,6 +6,7 @@
 #include "local_memshd.h"
 #include "../PlatformDeviceFd.h"
 #include "XLinkPrivateFields.h"
+#include "XLinkPublicDefines.h"
 
 #define MVLOG_UNIT_NAME local_memshd
 #include "XLinkLog.h"
@@ -43,7 +44,7 @@ int shdmemPlatformConnect(const char *devPathRead, const char *devPathWrite, voi
     strcpy(sockAddr.sun_path, socketPath);
 
     if (connect(socketFd, (struct sockaddr *)&sockAddr, sizeof(sockAddr)) < 0) {
-	mvLog(MVLOG_FATAL, "Socket connection failed");
+	mvLog(MVLOG_DEBUG, "Socket connection failed - err: %s\n", strerror(errno));
 	return X_LINK_ERROR;
     }
 
@@ -57,7 +58,6 @@ int shdmemPlatformConnect(const char *devPathRead, const char *devPathWrite, voi
 int shdmemPlatformServer(const char *devPathRead, const char *devPathWrite, void **desc, long *sockFd) {
     const char *socketPath = devPathWrite;
     mvLog(MVLOG_DEBUG, "Shared memory server invoked with socket path %s\n", socketPath);
-
     int socketFd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (socketFd < 0) {
 	    mvLog(MVLOG_FATAL, "Socket creation failed");
@@ -229,8 +229,27 @@ int shdmemSetProtocol(XLinkProtocol_t *protocol, const char* devPathRead, const 
 
 xLinkPlatformErrorCode_t shdmemGetDevices(const deviceDesc_t in_deviceRequirements, deviceDesc_t* out_foundDevices, int sizeFoundDevices, unsigned int *out_amountOfFoundDevices) {
     if (access(SHDMEM_DEFAULT_SOCKET, F_OK) != 0) {
-	return X_LINK_PLATFORM_ERROR;
+	    return X_LINK_PLATFORM_ERROR;
     }
+    // Test if the socket is accessible to determine the X_LINK state.
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        return X_LINK_PLATFORM_ERROR;
+    }
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SHDMEM_DEFAULT_SOCKET, sizeof(addr.sun_path) - 1);
+    XLinkDeviceState_t state = X_LINK_ANY_STATE;
+    if (connect(sock, (struct sockaddr *)&addr,
+                offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path) + 1) == 0) {
+        // Someone accepted the connection
+        state = X_LINK_BOOTED;
+    } else {
+        // If it failed, assume the fw isn't running.
+        state = X_LINK_GATE;
+    }
+    close(sock);
 
     // Status
     out_foundDevices[0].status = X_LINK_SUCCESS;
@@ -241,11 +260,11 @@ xLinkPlatformErrorCode_t shdmemGetDevices(const deviceDesc_t in_deviceRequiremen
     memset(out_foundDevices[0].mxid, 0, sizeof(out_foundDevices[0].mxid));
     strncpy(out_foundDevices[0].mxid, in_deviceRequirements.mxid, sizeof(out_foundDevices[0].mxid));
     // Platform
-    out_foundDevices[0].platform = X_LINK_MYRIAD_X;
+    out_foundDevices[0].platform = X_LINK_RVC4; // RVC4 only
     // Protocol
     out_foundDevices[0].protocol = X_LINK_LOCAL_SHDMEM;
     // State
-    out_foundDevices[0].state = X_LINK_BOOTED;
+    out_foundDevices[0].state = state;
 
     *out_amountOfFoundDevices = 1;
 

--- a/src/pc/protocols/local_memshd.cpp
+++ b/src/pc/protocols/local_memshd.cpp
@@ -5,6 +5,7 @@
 
 #include "local_memshd.h"
 #include "../PlatformDeviceFd.h"
+#include "XLinkPrivateFields.h"
 
 #define MVLOG_UNIT_NAME local_memshd
 #include "XLinkLog.h"
@@ -218,6 +219,10 @@ int shdmemPlatformWriteFd(void *desc, const long fd, void *data2, int size2) {
 int shdmemSetProtocol(XLinkProtocol_t *protocol, const char* devPathRead, const char* devPathWrite) {
     devPathWrite = devPathRead = SHDMEM_DEFAULT_SOCKET;
     *protocol = X_LINK_LOCAL_SHDMEM;
+    if (glHandler) {
+        glHandler->protocol = X_LINK_LOCAL_SHDMEM;
+        glHandler->isLocalConnection = true;
+    }
     return X_LINK_SUCCESS;
 }
 

--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <atomic>
 #include <cstddef>
+#include "XLinkPrivateFields.h"
 
 
 #define MVLOG_UNIT_NAME tcpip_host
@@ -937,6 +938,32 @@ int tcpipPlatformWrite(void *fdKey, void *data, int size)
     return 0;
 }
 
+int updateGlobalHandlerWithIsLocalConnectionInfo(struct sockaddr_in *client) {
+    if (!gHandler || !client) {
+        errno = EINVAL;
+        return -1;
+    }
+    gHandler->isLocalConnection = false;
+    struct ifaddrs *ifaddr = NULL;
+    if (getifaddrs(&ifaddr) == -1) {
+        return -1;
+    }
+
+    for (struct ifaddrs *ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr) continue;
+        if (ifa->ifa_addr->sa_family == AF_INET) {
+            struct sockaddr_in *sin = (struct sockaddr_in *)ifa->ifa_addr;
+
+            if (sin->sin_addr.s_addr == client->sin_addr.s_addr) {
+                gHandler->isLocalConnection = true;
+                break;
+            }
+        }
+    }
+    freeifaddrs(ifaddr);
+    return 0;
+}
+
 // TODO add IPv6 to tcpipPlatformConnect()
 int tcpipPlatformServer(const char *devPathRead, const char *devPathWrite, void **fd, long *sockFd)
 {
@@ -1013,6 +1040,9 @@ int tcpipPlatformServer(const char *devPathRead, const char *devPathWrite, void 
     {
         mvLog(MVLOG_FATAL, "Couldn't accept a connection to server socket");
         return X_LINK_PLATFORM_ERROR;
+    }
+    if (updateGlobalHandlerWithIsLocalConnectionInfo(&client) != 0) { // non fatal
+        mvLog(MVLOG_WARN, "Couldn't update XLinkGlobal state with isLocal info. %s\n", strerror(errno));
     }
 
     // Store the socket and create a "unique" key instead

--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -939,29 +939,35 @@ int tcpipPlatformWrite(void *fdKey, void *data, int size)
 }
 
 int updateGlobalHandlerWithIsLocalConnectionInfo(struct sockaddr_in *client) {
-    if (!gHandler || !client) {
+    if (!glHandler || !client) {
         errno = EINVAL;
         return -1;
     }
-    gHandler->isLocalConnection = false;
+    glHandler->isLocalConnection = false;
+
+#if defined(__unix__) || defined(__APPLE__)
     struct ifaddrs *ifaddr = NULL;
     if (getifaddrs(&ifaddr) == -1) {
         return -1;
     }
-
     for (struct ifaddrs *ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
         if (!ifa->ifa_addr) continue;
         if (ifa->ifa_addr->sa_family == AF_INET) {
             struct sockaddr_in *sin = (struct sockaddr_in *)ifa->ifa_addr;
 
             if (sin->sin_addr.s_addr == client->sin_addr.s_addr) {
-                gHandler->isLocalConnection = true;
+                glHandler->isLocalConnection = true;
                 break;
             }
         }
     }
     freeifaddrs(ifaddr);
     return 0;
+#else
+    // Not supported on this platform
+    errno = ENOTSUP;
+    return -1;
+#endif
 }
 
 // TODO add IPv6 to tcpipPlatformConnect()

--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -938,14 +938,13 @@ int tcpipPlatformWrite(void *fdKey, void *data, int size)
     return 0;
 }
 
+#if defined(__unix__) || defined(__APPLE__)
 int updateGlobalHandlerWithIsLocalConnectionInfo(struct sockaddr_in *client) {
     if (!glHandler || !client) {
         errno = EINVAL;
         return -1;
     }
     glHandler->isLocalConnection = false;
-
-#if defined(__unix__) || defined(__APPLE__)
     struct ifaddrs *ifaddr = NULL;
     if (getifaddrs(&ifaddr) == -1) {
         return -1;
@@ -963,12 +962,8 @@ int updateGlobalHandlerWithIsLocalConnectionInfo(struct sockaddr_in *client) {
     }
     freeifaddrs(ifaddr);
     return 0;
-#else
-    // Not supported on this platform
-    errno = ENOTSUP;
-    return -1;
-#endif
 }
+#endif
 
 // TODO add IPv6 to tcpipPlatformConnect()
 int tcpipPlatformServer(const char *devPathRead, const char *devPathWrite, void **fd, long *sockFd)
@@ -1047,9 +1042,11 @@ int tcpipPlatformServer(const char *devPathRead, const char *devPathWrite, void 
         mvLog(MVLOG_FATAL, "Couldn't accept a connection to server socket");
         return X_LINK_PLATFORM_ERROR;
     }
+#if defined(__unix__) || defined(__APPLE__)
     if (updateGlobalHandlerWithIsLocalConnectionInfo(&client) != 0) { // non fatal
         mvLog(MVLOG_WARN, "Couldn't update XLinkGlobal state with isLocal info. %s\n", strerror(errno));
     }
+#endif
 
     // Store the socket and create a "unique" key instead
     // (as file descriptors are reused and can cause a clash with lookups between scheduler and link)

--- a/src/pc/protocols/tcpip_memshd.cpp
+++ b/src/pc/protocols/tcpip_memshd.cpp
@@ -100,7 +100,10 @@ int tcpipOrLocalShdmemPlatformServer(XLinkProtocol_t *protocol, const char *devP
     // Asign the final protocol (once both threads finalize)
     if(retTcpIp == 0) {
         *fd = fdTcpIp;
-	*protocol = X_LINK_TCP_IP;
+        *protocol = X_LINK_TCP_IP;
+        if (glHandler) {
+            glHandler->protocol = X_LINK_TCP_IP;
+        }
     }
 
     if(retShdmem == X_LINK_SUCCESS) {

--- a/src/pc/protocols/tcpip_memshd.cpp
+++ b/src/pc/protocols/tcpip_memshd.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include <cstdio>
+#include "XLinkPrivateFields.h"
 
 #if defined(__unix__)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Added isLocalConnection to global xlink state and implemented the detection of this case.
This is needed for the depthai based setup app where the depthai device should be available for use on the device side.

- [x] TODO: Fix unix domain socket multi reconnects.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested locally with custom dai fw which relies on this flag.

Tested both UNIX sock and INET sock code paths - forcing each with dai.DeviceInfo.