### PR TITLE
Added immediate ACKs on Windows, similar to TCP_QUICKACK

### DIFF
--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -33,6 +33,7 @@
 #pragma comment(lib, "iphlpapi.lib")
 #define tcpip_errno WSAGetLastError()
 #define ERRNO_EAGAIN WSAETIMEDOUT
+#define SIO_TCP_SET_ACK_FREQUENCY _WSAIOW(IOC_VENDOR, 23)
 
 #else
 
@@ -1120,9 +1121,9 @@ int tcpipPlatformConnect(const char *devPathRead, const char *devPathWrite, void
     // Force immediate ACKs
     int freq = 1;
     DWORD bytes;
-    if(WSAIoctl(sock, _WSAIOW(IOC_VENDOR, 23), &freq, sizeof(freq), NULL, 0, &bytes, NULL, NULL) != 0)
+    if(WSAIoctl(sock, SIO_TCP_SET_ACK_FREQUENCY, &freq, sizeof(freq), NULL, 0, &bytes, NULL, NULL) != 0)
     {
-        mvLog(MVLOG_WARN, "WSAIoctl _WSAIOW(IOC_VENDOR, 23) could not be set");
+        mvLog(MVLOG_WARN, "WSAIoctl SIO_TCP_SET_ACK_FREQUENCY could not be set");
     }
 #endif
 

--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -1116,6 +1116,16 @@ int tcpipPlatformConnect(const char *devPathRead, const char *devPathWrite, void
         return -1;
     }
 
+#if (defined(_WIN32) || defined(_WIN64) )
+    // Force immediate ACKs
+    int freq = 1;
+    DWORD bytes;
+    if(WSAIoctl(sock, _WSAIOW(IOC_VENDOR, 23), &freq, sizeof(freq), NULL, 0, &bytes, NULL, NULL) != 0)
+    {
+        mvLog(MVLOG_WARN, "WSAIoctl _WSAIOW(IOC_VENDOR, 23) could not be set");
+    }
+#endif
+
 #if defined(TCP_QUICKACK)
     if(tcpip_setsockopt(sock, IPPROTO_TCP, TCP_QUICKACK, &on, sizeof(on)) < 0)
     {


### PR DESCRIPTION
## Purpose
This fix solves an issue caused by default Windows behaviour, where the receiver (host) does not send Acknowledgment immediately when receiving packets, but rather waits up to 200ms before sending the ACK. Because of this, the device believes the host is not reading packets fast enough, which causes a warning.

## Specification
Immediate acknowledgment is now forced, similar to TCP_QUICKACK

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
This was tested on a Windows testbed, with an example where such issues were observed.