### PR TITLE
Set TCP_NODELAY on server side

### DIFF
--- a/src/pc/protocols/tcpip_host.cpp
+++ b/src/pc/protocols/tcpip_host.cpp
@@ -1048,6 +1048,15 @@ int tcpipPlatformServer(const char *devPathRead, const char *devPathWrite, void 
         return X_LINK_PLATFORM_ERROR;
     }
 
+    // Disable Nagle to reduce latency on the accepted connection
+    int on = 1;
+    if(tcpip_setsockopt(connfd, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) < 0)
+    {
+        perror("setsockopt TCP_NODELAY (server)");
+        tcpip_close_socket(connfd);
+        return X_LINK_PLATFORM_ERROR;
+    }
+
     // Store the socket and create a "unique" key instead
     // (as file descriptors are reused and can cause a clash with lookups between scheduler and link)
     *fd = createPlatformDeviceFdKey((void*) (uintptr_t) connfd);


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Alternative to https://github.com/luxonis/XLink/pull/101
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable