### PR TITLE
Fix ASAN/UBSAN issues

### DIFF
--- a/include/XLink/XLinkPrivateFields.h
+++ b/include/XLink/XLinkPrivateFields.h
@@ -15,7 +15,7 @@
 #define EXTRACT_STREAM_ID(streamId) ((streamId) & STREAM_ID_MASK)
 
 #define COMBINE_IDS(streamId, linkid) \
-    streamId = streamId | ((linkid & LINK_ID_MASK) << LINK_ID_SHIFT);
+    streamId = streamId | (((uint32_t)(linkid) & LINK_ID_MASK) << LINK_ID_SHIFT);
 
 // ------------------------------------
 // Global fields declaration. Begin.

--- a/include/XLink/XLinkPrivateFields.h
+++ b/include/XLink/XLinkPrivateFields.h
@@ -15,7 +15,7 @@
 #define EXTRACT_STREAM_ID(streamId) ((streamId) & STREAM_ID_MASK)
 
 #define COMBINE_IDS(streamId, linkid) \
-    streamId = streamId | (((uint32_t)(linkid) & LINK_ID_MASK) << LINK_ID_SHIFT);
+    streamId = streamId | (((uint32_t)linkid & LINK_ID_MASK) << LINK_ID_SHIFT);
 
 // ------------------------------------
 // Global fields declaration. Begin.

--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -770,6 +770,7 @@ xLinkPlatformErrorCode_t usbLinkOpen(const char *path, libusb_device_handle*& h)
 
     uint8_t ep = 0;
     libusb_error libusb_rc = usb_open_device(dev, &ep, h);
+    libusb_unref_device(dev);
     if(libusb_rc == LIBUSB_SUCCESS) {
         return X_LINK_PLATFORM_SUCCESS;
     } else if(libusb_rc == LIBUSB_ERROR_ACCESS) {


### PR DESCRIPTION
## Purpose
Added minor fixes to solve issues detected by ASAN/UBSAN.

## Specification
This solves 2 issues, firstly: `result of byte shift cannot be represented with type int` and also a memory leak originating from missing unreferencing of a libusb device. 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
This was tested with the sanitizers, and later using the HIL tests.