### PR TITLE
Add configurable timeouts to XLinkConnect and XLinkOpenStream

### DIFF
--- a/include/XLink/XLink.h
+++ b/include/XLink/XLink.h
@@ -89,11 +89,20 @@ XLinkError_t XLinkSearchForDevices(const deviceDesc_t in_deviceRequirements,
 
 
 /**
- * @brief Connects to specific device, starts dispatcher and pings remote
+ * @brief Connects to specific device, starts dispatcher and pings remote.
+ *        Uses XLINK_CONNECT_TIMEOUT as the default timeout for the ping handshake.
  * @param[in,out] handler - XLink communication parameters (file path name for underlying layer)
  * @return Status code of the operation: X_LINK_SUCCESS (0) for success
  */
 XLinkError_t XLinkConnect(XLinkHandler_t* handler);
+
+/**
+ * @brief Connects to specific device with a configurable timeout for the ping handshake.
+ * @param[in,out] handler - XLink communication parameters (file path name for underlying layer)
+ * @param[in] timeoutMs - timeout in milliseconds for the ping round-trip. Use XLINK_NO_RW_TIMEOUT for infinite wait.
+ * @return Status code of the operation: X_LINK_SUCCESS (0) for success, X_LINK_TIMEOUT on timeout
+ */
+XLinkError_t XLinkConnectWithTimeout(XLinkHandler_t* handler, unsigned int timeoutMs);
 
 /**
  * @brief Puts device into bootloader mode
@@ -214,14 +223,26 @@ XLinkError_t XLinkGetProfilingData(linkId_t id, XLinkProf_t* prof);
 // ------------------------------------
 
 /**
- * @brief Opens a stream in the remote that can be written to by the local
- *        Allocates stream_write_size (aligned up to 64 bytes) for that stream
+ * @brief Opens a stream in the remote that can be written to by the local.
+ *        Allocates stream_write_size (aligned up to 64 bytes) for that stream.
+ *        Uses XLINK_OPEN_STREAM_TIMEOUT as the default timeout.
  * @param[in] id - link Id obtained from XLinkConnect in the handler parameter
  * @param[in] name - stream name
  * @param[in] stream_write_size - stream buffer size
  * @return Link Id: INVALID_STREAM_ID for failure
  */
 streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size);
+
+/**
+ * @brief Opens a stream with a configurable timeout.
+ *        Allocates stream_write_size (aligned up to 64 bytes) for that stream.
+ * @param[in] id - link Id obtained from XLinkConnect in the handler parameter
+ * @param[in] name - stream name
+ * @param[in] stream_write_size - stream buffer size
+ * @param[in] timeoutMs - timeout in milliseconds. Use XLINK_NO_RW_TIMEOUT for infinite wait.
+ * @return Link Id: INVALID_STREAM_ID for failure (including timeout)
+ */
+streamId_t XLinkOpenStreamWithTimeout(linkId_t id, const char* name, int stream_write_size, unsigned int timeoutMs);
 
 /**
  * @brief Closes stream for any further data transfer

--- a/include/XLink/XLinkPublicDefines.h
+++ b/include/XLink/XLinkPublicDefines.h
@@ -27,6 +27,8 @@ extern "C"
 #endif
 #define XLINK_MAX_PACKETS_PER_STREAM 64
 #define XLINK_NO_RW_TIMEOUT 0xFFFFFFFF
+#define XLINK_CONNECT_TIMEOUT 5000        /* 5s default timeout for XLinkConnect ping handshake */
+#define XLINK_OPEN_STREAM_TIMEOUT 5000    /* 5s default timeout for XLinkOpenStream */
 
 
 typedef enum {

--- a/src/shared/XLinkData.c
+++ b/src/shared/XLinkData.c
@@ -45,11 +45,16 @@ static XLinkError_t getLinkByStreamId(streamId_t streamId, xLinkDesc_t** out_lin
 
 streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size)
 {
+    return XLinkOpenStreamWithTimeout(id, name, stream_write_size, XLINK_OPEN_STREAM_TIMEOUT);
+}
+
+streamId_t XLinkOpenStreamWithTimeout(linkId_t id, const char* name, int stream_write_size, unsigned int timeoutMs)
+{
     XLINK_RET_ERR_IF(name == NULL, INVALID_STREAM_ID);
     XLINK_RET_ERR_IF(stream_write_size < 0, INVALID_STREAM_ID);
 
     xLinkDesc_t* link = getLinkById(id);
-    mvLog(MVLOG_DEBUG,"%s() id %d link %p\n", __func__, id, link);
+    mvLog(MVLOG_DEBUG,"%s() id %d link %p timeout %u\n", __func__, id, link, timeoutMs);
     XLINK_RET_ERR_IF(link == NULL, INVALID_STREAM_ID);
     XLINK_RET_ERR_IF(getXLinkState(link) != XLINK_UP, INVALID_STREAM_ID);
     XLINK_RET_ERR_IF(strlen(name) >= MAX_STREAM_NAME_LENGTH, INVALID_STREAM_ID);
@@ -65,9 +70,10 @@ streamId_t XLinkOpenStream(linkId_t id, const char* name, int stream_write_size)
                    name, MAX_STREAM_NAME_LENGTH - 1);
 
         DispatcherAddEvent(EVENT_LOCAL, &event);
-        XLINK_RET_ERR_IF(
-            DispatcherWaitEventComplete(&link->deviceHandle, XLINK_NO_RW_TIMEOUT),
-            INVALID_STREAM_ID);
+        if (DispatcherWaitEventComplete(&link->deviceHandle, timeoutMs)) {
+            mvLog(MVLOG_ERROR, "Open stream \"%s\" timed out after %u ms", name, timeoutMs);
+            return INVALID_STREAM_ID;
+        }
 
 #ifndef __DEVICE__
         XLinkError_t eventStatus = checkEventHeader(event.header);

--- a/src/shared/XLinkDevice.c
+++ b/src/shared/XLinkDevice.c
@@ -227,6 +227,12 @@ XLinkError_t XLinkSearchForDevices(const deviceDesc_t in_deviceRequirements,
 //Called only from app - per device
 XLinkError_t XLinkConnect(XLinkHandler_t* handler)
 {
+    return XLinkConnectWithTimeout(handler, XLINK_CONNECT_TIMEOUT);
+}
+
+//Called only from app - per device, with configurable timeout
+XLinkError_t XLinkConnectWithTimeout(XLinkHandler_t* handler, unsigned int timeoutMs)
+{
     XLINK_RET_IF(handler == NULL);
     if (strnlen(handler->devicePath, MAX_PATH_LENGTH) < 2) {
         mvLog(MVLOG_ERROR, "Device path is incorrect");
@@ -235,7 +241,7 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
 
     xLinkDesc_t* link = getNextAvailableLink();
     XLINK_RET_IF(link == NULL);
-    mvLog(MVLOG_DEBUG,"%s() device name %s glHandler %p protocol %d\n", __func__, handler->devicePath, glHandler, handler->protocol);
+    mvLog(MVLOG_DEBUG,"%s() device name %s glHandler %p protocol %d timeout %u\n", __func__, handler->devicePath, glHandler, handler->protocol, timeoutMs);
 
     link->deviceHandle.protocol = handler->protocol;
     int connectStatus = XLinkPlatformConnect(handler->devicePath2, handler->devicePath,
@@ -263,7 +269,8 @@ XLinkError_t XLinkConnect(XLinkHandler_t* handler)
     event.deviceHandle = link->deviceHandle;
     DispatcherAddEvent(EVENT_LOCAL, &event);
 
-    if (DispatcherWaitEventComplete(&link->deviceHandle, XLINK_NO_RW_TIMEOUT)) {
+    if (DispatcherWaitEventComplete(&link->deviceHandle, timeoutMs)) {
+        mvLog(MVLOG_ERROR, "Ping handshake timed out after %u ms", timeoutMs);
         DispatcherClean(&link->deviceHandle);
         return X_LINK_TIMEOUT;
     }

--- a/src/shared/XLinkDispatcher.c
+++ b/src/shared/XLinkDispatcher.c
@@ -417,19 +417,31 @@ int DispatcherWaitEventComplete(xLinkDeviceHandle_t *deviceHandle, unsigned int 
 
     int rc = 0;
     if (timeoutMs != XLINK_NO_RW_TIMEOUT) {
-        // This is a workaround for sem_timedwait being influenced by the system clock change.
-        // This is a temporary solution. TODO: replace this with something more efficient.
-        while (timeoutMs--) {
+        // Use monotonic clock to measure elapsed time accurately.
+        // This replaces the previous iteration-counting workaround that was added
+        // because sem_timedwait uses CLOCK_REALTIME (affected by NTP/clock jumps).
+        // steady_clock/CLOCK_MONOTONIC is immune to system clock changes.
+        XLinkTimespec start;
+        getMonotonicTimestamp(&start);
+        uint64_t startMs = start.tv_sec * 1000 + start.tv_nsec / 1000000;
+
+        while (1) {
             rc = XLink_sem_trywait(id);
             if (!rc) {
                 break;
-            } else {
-#if (defined(_WIN32) || defined(_WIN64) )
-                Sleep(1);
-#else
-                usleep(1000);
-#endif
             }
+            XLinkTimespec now;
+            getMonotonicTimestamp(&now);
+            uint64_t nowMs = now.tv_sec * 1000 + now.tv_nsec / 1000000;
+            if (nowMs - startMs >= timeoutMs) {
+                rc = -1;
+                break;
+            }
+#if (defined(_WIN32) || defined(_WIN64) )
+            Sleep(1);
+#else
+            usleep(1000);
+#endif
         }
     } else {
         while(((rc = XLink_sem_wait(id)) == -1) && errno == EINTR)


### PR DESCRIPTION
## Summary

`XLinkConnect()` and `XLinkOpenStream()` pass `XLINK_NO_RW_TIMEOUT` to `DispatcherWaitEventComplete()`, which results in a bare `sem_wait()` that blocks the calling thread indefinitely if the remote device fails to respond after firmware boot. This is the same pattern that PR #5 addressed for data read/write operations, but the connect and stream-open paths were not covered.

Additionally, the timeout path in `DispatcherWaitEventComplete` used iteration counting (`while (timeoutMs--)` with `usleep(1000)`) to approximate timeout duration. This was inaccurate because `usleep(1000)` can sleep 1-10ms depending on system load, making a "5000ms" timeout anywhere from 5s to 50s in practice.

## Changes

### Commit 1: Add configurable timeouts to XLinkConnect and XLinkOpenStream

- `XLinkConnectWithTimeout(handler, timeoutMs)` — connect with configurable ping timeout
- `XLinkOpenStreamWithTimeout(id, name, size, timeoutMs)` — open stream with configurable timeout
- `XLINK_CONNECT_TIMEOUT` (5s) and `XLINK_OPEN_STREAM_TIMEOUT` (5s) default constants
- `XLinkConnect()` and `XLinkOpenStream()` now delegate to the `WithTimeout` variants using these defaults

### Commit 2: Replace iteration-counting timeout with monotonic clock measurement

Replaces the `while (timeoutMs--)` polling loop with `getMonotonicTimestamp()` (backed by `std::chrono::steady_clock`, already in the codebase via `XLinkTime.h`). This:
- Gives accurate timeouts regardless of system load or scheduler granularity
- Remains immune to NTP/system clock jumps (the original reason `sem_timedwait` was replaced)
- Resolves the TODO: *"This is a temporary solution. TODO: replace this with something more efficient."*
- Related: #86

## Motivation

When a device firmware fails to initialize its XLink dispatcher after boot (e.g. due to a firmware hang or hardware instability), the host-side `XLinkConnect()` PING handshake blocks forever in `DispatcherWaitEventComplete()`. Since watchdog threads in depthai-core are created *after* `XLinkConnect` and `XLinkOpenStream` complete, there is no recovery mechanism — the calling thread is permanently stuck.

With this change, these operations time out after 5 seconds by default. For a responsive device, PING and stream creation complete in well under 100ms, so the 5s default has no impact on normal operation. Callers can pass `XLINK_NO_RW_TIMEOUT` to the `WithTimeout` variants to restore the previous infinite-wait behavior if needed.

## Files Modified

| File | Change |
|------|--------|
| `include/XLink/XLinkPublicDefines.h` | Add `XLINK_CONNECT_TIMEOUT` and `XLINK_OPEN_STREAM_TIMEOUT` constants |
| `include/XLink/XLink.h` | Declare `XLinkConnectWithTimeout()` and `XLinkOpenStreamWithTimeout()` |
| `src/shared/XLinkDevice.c` | Implement `XLinkConnectWithTimeout()`, `XLinkConnect()` delegates to it |
| `src/shared/XLinkData.c` | Implement `XLinkOpenStreamWithTimeout()`, `XLinkOpenStream()` delegates to it |
| `src/shared/XLinkDispatcher.c` | Replace iteration-counting with monotonic clock measurement |

## Backward Compatibility

- **Fully backward compatible**: existing callers of `XLinkConnect()` and `XLinkOpenStream()` require no changes
- The only behavioral change is that these operations now time out after 5s instead of waiting forever
- The `WithTimeout` API follows the same pattern as the existing `XLinkWriteDataWithTimeout` / `XLinkReadDataWithTimeout` / `XLinkReadMoveDataWithTimeout`

## Test Plan

- [ ] Build on Linux and Windows
- [ ] Normal device connection works (PING completes in <100ms, well within 5s timeout)
- [ ] When device firmware is unresponsive, `XLinkConnect` returns `X_LINK_TIMEOUT` after 5s instead of hanging
- [ ] depthai-core connect retry loop in `XLinkConnection::initDevice()` can now retry on timeout
- [ ] Timeout accuracy: verify 5s timeout completes in ~5s regardless of system load
