### PR TITLE
Skip temporarily booted devices, which vanish during MXID read

### DIFF
--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -239,6 +239,14 @@ xLinkPlatformErrorCode_t getUSBDevices(const deviceDesc_t in_deviceRequirements,
                 // Get device mxid
                 libusb_error rc = getLibusbDeviceMxId(state, devicePath, &desc, devs[i], mxId);
                 mvLog(MVLOG_DEBUG, "getLibusbDeviceMxId returned: %s", xlink_libusb_strerror(rc));
+                if(state == X_LINK_BOOTED && rc == LIBUSB_ERROR_NO_DEVICE) {
+                    mvLog(MVLOG_WARN,
+                          "Skipping temporarily booted device %s during USB search because it disappeared while reading MXID (libusb rc: %d, msg: %s)",
+                          devicePath.c_str(),
+                          static_cast<int>(rc),
+                          xlink_libusb_strerror(rc));
+                    continue;
+                }
                 switch (rc)
                 {
                 case LIBUSB_SUCCESS:


### PR DESCRIPTION
## Purpose
Fixes an XLink issue, where an RVC2 USB device could temporarily become booted during reset, but later becomes disconnected resulting in LIBUSB_ERROR_NO_DEVICE. 
This PR changes the behaviour, such that a device with this return code is no longer added to the found devices - as the device is no longer connected.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: GPTCodex 5.4

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
