### PR TITLE
Fix std::string creation for deviceId

### DIFF
--- a/src/pc/protocols/usb_host.cpp
+++ b/src/pc/protocols/usb_host.cpp
@@ -633,7 +633,6 @@ libusb_error getLibusbDeviceMxId(XLinkDeviceState_t state, std::string devicePat
 
 static libusb_error getLibusbDeviceGateResponse(const libusb_device_descriptor* pDesc, libusb_device *dev, GateResponse& outGateResponse, std::string& outSerial) {
     GateResponse gateResponse = {0};
-    std::string serial = "";
 
     // get serial from usb descriptor
     libusb_device_handle *handle = nullptr;
@@ -676,12 +675,8 @@ static libusb_error getLibusbDeviceGateResponse(const libusb_device_descriptor* 
 
 
     size_t serialStrLen = usbGateResponse.RequestSize - sizeof(GateResponse);
-    serial.resize(serialStrLen + 1);
-    for (int i = 0; i < serialStrLen; ++i) {
-        serial[i] = respBuffer[i];
-    }
-    serial[serialStrLen] = '\0';
-    outSerial = serial;
+    const auto serialEnd = std::find(respBuffer.begin(), respBuffer.begin() + serialStrLen, 0);
+    outSerial.assign(reinterpret_cast<const char*>(respBuffer.data()), std::distance(respBuffer.begin(), serialEnd));
 
     memcpy(&gateResponse, &respBuffer[serialStrLen], sizeof(gateResponse));
     outGateResponse = gateResponse;


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
DeviceIDs std::strings contained a nullterminated string which then failed in comparisons with the target mxID

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested manually & statically validated.

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: /

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
